### PR TITLE
Allow ssh access to devtainers

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -27,13 +27,13 @@ ENV BASH_ENV=/tmp/theia-bash-env
 # under https://github.com/erebe/wstunnel/blob/master/LICENSE.
 RUN if [ "${TARGETPLATFORM}" = "linux/amd64" ]; then \
       THEIA_VERSION=1.40.0; \
-      WSTUNNEL_BINARY="https://storage.googleapis.com/dockside/wstunnel/wstunnel-v5.0-linux-x86_64"; \
+      WSTUNNEL_BINARY="https://storage.googleapis.com/dockside/wstunnel/v6.0/wstunnel-v6.0-linux-x64"; \
     elif [ "${TARGETPLATFORM}" = "linux/arm64" ]; then \
       THEIA_VERSION=1.40.0; \
-      WSTUNNEL_BINARY="https://storage.googleapis.com/dockside/wstunnel/wstunnel-v5.0-linux-arm64"; \
+      WSTUNNEL_BINARY="https://storage.googleapis.com/dockside/wstunnel/v6.0/wstunnel-v6.0-linux-arm64"; \
     elif [ "${TARGETPLATFORM}" = "linux/arm/v7" ]; then \
       THEIA_VERSION=1.35.0; \
-      WSTUNNEL_BINARY="https://storage.googleapis.com/dockside/wstunnel/wstunnel-v5.1-linux-armv7"; \
+      WSTUNNEL_BINARY="https://storage.googleapis.com/dockside/wstunnel/v6.0/wstunnel-v6.0-linux-armv7"; \
     else \
       echo "Build error: Unsupported architecture '$TARGETPLATFORM'" >&2; \
       exit 1; \

--- a/Dockerfile
+++ b/Dockerfile
@@ -4,7 +4,7 @@ ARG ALPINE_VERSION=3.14
 FROM node:${NODE_VERSION}-alpine${ALPINE_VERSION} as theia-build
 
 RUN apk update && \
-    apk add --no-cache make gcc g++ python3 libsecret-dev s6 curl file patchelf bash
+    apk add --no-cache make gcc g++ python3 libsecret-dev s6 curl file patchelf bash dropbear jq
 
 ARG OPT_PATH
 ARG TARGETPLATFORM
@@ -73,9 +73,7 @@ RUN yarn autoclean --init && \
 
 FROM theia-clean as theia-findelfs
 
-ENV BINARIES="node busybox s6-svscan curl dropbear dropbearkey"
-
-RUN apk add --no-cache dropbear
+ENV BINARIES="node busybox s6-svscan curl dropbear dropbearkey jq"
 
 RUN /tmp/build/ide/theia/elf-patcher.sh --findelfs
 

--- a/Dockerfile
+++ b/Dockerfile
@@ -294,6 +294,10 @@ RUN cp -a ~/$APP/build/development/dot-theia .theia && \
 #
 VOLUME $OPT_PATH
 
+# Create a separate volume for host-specific data to be shared
+# read-only with devtainers
+VOLUME $OPT_PATH/host
+
 ################################################################################
 # INITIALISE /opt/dockside/bin
 #
@@ -304,7 +308,7 @@ VOLUME $OPT_PATH
 #
 USER root
 RUN . /tmp/theia-bash-env && \
-    mkdir -p $OPT_PATH/bin && \
+    mkdir -p $OPT_PATH/bin $OPT_PATH/host && \
     cp -a $HOME/$APP/app/scripts/container/launch.sh $OPT_PATH/bin/ && \
     ln -sfr $OPT_PATH/bin/launch.sh $OPT_PATH/launch.sh && \
     cp -a $HOME/$APP/app/server/assets/ico/favicon.ico $THEIA_PATH/theia/lib/ && \

--- a/Dockerfile
+++ b/Dockerfile
@@ -60,7 +60,10 @@ RUN mkdir -p $THEIA_PATH && \
     cp -a /tmp/build/ide/theia/$THEIA_VERSION/bin $THEIA_PATH/
 
 # Build Theia
-RUN PUPPETEER_SKIP_CHROMIUM_DOWNLOAD=1 && NODE_OPTIONS="--max_old_space_size=4096" && yarn config set network-timeout 600000 -g && yarn
+RUN PUPPETEER_SKIP_CHROMIUM_DOWNLOAD=1 && \
+    PUPPETEER_SKIP_DOWNLOAD=1 && \
+    NODE_OPTIONS="--max_old_space_size=4096" && \
+    yarn config set network-timeout 600000 -g && yarn
 
 # Default diagnostics entrypoint for this stage
 # (and the next, which inherits it)

--- a/Dockerfile
+++ b/Dockerfile
@@ -21,6 +21,10 @@ ARG TARGETPLATFORM
 #
 ENV BASH_ENV=/tmp/theia-bash-env
 
+# Some but not all needed wstunnel binaries are published on https://github.com/erebe/wstunnel.
+# Others we have had to compile from source. To ensure build reliability/reproducibility, we here
+# obtain wstunnel binaries from the Dockside Google Cloud Storage bucket. wstunnel is published
+# under https://github.com/erebe/wstunnel/blob/master/LICENSE.
 RUN if [ "${TARGETPLATFORM}" = "linux/amd64" ]; then \
       THEIA_VERSION=1.40.0; \
       WSTUNNEL_BINARY="https://storage.googleapis.com/dockside/wstunnel/wstunnel-v5.0-linux-x86_64"; \

--- a/Dockerfile
+++ b/Dockerfile
@@ -73,7 +73,9 @@ RUN yarn autoclean --init && \
 
 FROM theia-clean as theia-findelfs
 
-ENV BINARIES="node busybox s6-svscan curl"
+ENV BINARIES="node busybox s6-svscan curl dropbear dropbearkey"
+
+RUN apk add --no-cache dropbear
 
 RUN /tmp/build/ide/theia/elf-patcher.sh --findelfs
 
@@ -92,7 +94,8 @@ RUN /tmp/build/ide/theia/elf-patcher.sh --patchelfs && \
     cd $THEIA_PATH/bin && \
     ln -sf busybox sh && \
     ln -sf busybox su && \
-    ln -sf busybox pgrep
+    ln -sf busybox pgrep && \
+    curl -L -o wstunnel https://github.com/erebe/wstunnel/releases/download/v5.1/wstunnel-linux-x64 && chmod 755 wstunnel
 
 # Default diagnostics entrypoint for this stage (uses patched node)
 ENTRYPOINT ["/tmp/theia-exec", "../bin/node", "./src-gen/backend/main.js", "/root", "--hostname", "0.0.0.0", "--port", "3131"]

--- a/app/client/src/components/App.vue
+++ b/app/client/src/components/App.vue
@@ -5,6 +5,7 @@
          <b-row>
             <Sidebar></Sidebar>
             <Main></Main>
+            <SSHInfo></SSHInfo>
          </b-row>
       </b-container>
       <Footer></Footer>
@@ -16,6 +17,7 @@
    import Footer from '@/components/Footer';
    import Sidebar from '@/components/Sidebar';
    import Main from '@/components/Main';
+   import SSHInfo from '@/components/SSHInfo';
 
    export default {
       name: 'App',
@@ -23,7 +25,8 @@
          Header,
          Footer,
          Sidebar,
-         Main
+         Main,
+         SSHInfo
       },
       created() {
          this.updateStateFromRoute(this.$route);

--- a/app/client/src/components/Container.vue
+++ b/app/client/src/components/Container.vue
@@ -319,7 +319,9 @@
             copyToClipboard(value);
          },
          makeUri(router) {
-            return [router.https ? 'https' : 'http', '://', (router.prefixes[0] ? router.prefixes[0] : 'www'), '-', this.container.name, window.dockside.host].join('');
+            return router.type !== 'ssh' ? 
+              [router.https ? 'https' : 'http', '://', (router.prefixes[0] ? router.prefixes[0] : 'www'), '-', this.container.name, window.dockside.host].join('') :
+              ['ssh://dockside@', (router.prefixes[0] ? router.prefixes[0] : 'www'), '-', this.container.name, window.dockside.host].join('');
          },
          makeUriTarget(router) {
             return [(router.prefixes[0] ? router.prefixes[0] : 'www'), '-', this.container.name, window.dockside.host].join('');

--- a/app/client/src/components/Container.vue
+++ b/app/client/src/components/Container.vue
@@ -88,7 +88,7 @@
                            <th>&#8674;&nbsp;{{ router.name }} </th>
                            <td v-if="!isEditMode && !isPrelaunchMode">
                               <b-button v-if="router.type != 'passthru' && container.status == 1" size="sm" variant="primary" v-bind:href="makeUri(router)" :target="makeUriTarget(router)">Open</b-button>
-                              <b-button v-if="router.type != 'passthru' && container.status >= 0" size="sm" variant="outline-secondary" v-on:click="copy(makeUri(router))">Copy</b-button>
+                              <b-button v-if="router.type != 'passthru' && container.status >= 0" size="sm" variant="outline-secondary" v-on:click="copyUri(router)">Copy</b-button>
                               <b-button v-if="router.type === 'ssh' && container.status >= 0" size="sm" variant="outline-secondary" type="button" v-b-modal="'sshinfo-modal'" v-b-tooltip title="Configure SSH for Dockside">Setup</b-button>
                               ({{ container.meta.access[router.name] }} access)
                            </td>
@@ -323,6 +323,12 @@
             return router.type !== 'ssh' ? 
               [router.https ? 'https' : 'http', '://', (router.prefixes[0] ? router.prefixes[0] : 'www'), '-', this.container.name, window.dockside.host].join('') :
               ['ssh://dockside@', (router.prefixes[0] ? router.prefixes[0] : 'www'), '-', this.container.name, window.dockside.host].join('');
+         },
+         copyUri(router) {
+            return router.type !== 'ssh' ? copyToClipboard(this.makeUri(router)) :
+               copyToClipboard(
+                 ['ssh ', 'dockside@', (router.prefixes[0] ? router.prefixes[0] : 'www'), '-', this.container.name, window.dockside.host].join('')
+               );
          },
          makeUriTarget(router) {
             return [(router.prefixes[0] ? router.prefixes[0] : 'www'), '-', this.container.name, window.dockside.host].join('');

--- a/app/client/src/components/Container.vue
+++ b/app/client/src/components/Container.vue
@@ -320,14 +320,15 @@
             copyToClipboard(value);
          },
          makeUri(router) {
+            console.log(this.container);
             return router.type !== 'ssh' ? 
               [router.https ? 'https' : 'http', '://', (router.prefixes[0] ? router.prefixes[0] : 'www'), '-', this.container.name, window.dockside.host].join('') :
-              ['ssh://dockside@', (router.prefixes[0] ? router.prefixes[0] : 'www'), '-', this.container.name, window.dockside.host].join('');
+              ['ssh://',this.container.data.unixuser,'@', (router.prefixes[0] ? router.prefixes[0] : 'www'), '-', this.container.name, window.dockside.host].join('');
          },
          copyUri(router) {
             return router.type !== 'ssh' ? copyToClipboard(this.makeUri(router)) :
                copyToClipboard(
-                 ['ssh ', 'dockside@', (router.prefixes[0] ? router.prefixes[0] : 'www'), '-', this.container.name, window.dockside.host].join('')
+                 ['ssh ', this.container.data.unixuser,'@', (router.prefixes[0] ? router.prefixes[0] : 'www'), '-', this.container.name, window.dockside.host].join('')
                );
          },
          makeUriTarget(router) {

--- a/app/client/src/components/Container.vue
+++ b/app/client/src/components/Container.vue
@@ -344,7 +344,7 @@
             const unixuser = this.container.data.unixuser;
             const hostname = host.split(':')[0];
 
-            return `ssh ${unixuser}@${prefix}-${containerName}${hostname}`;
+            return copyToClipboard(`ssh ${unixuser}@${prefix}-${containerName}${hostname}`);
          },
          makeUriTarget(router) {
             return [(router.prefixes[0] ? router.prefixes[0] : 'www'), '-', this.container.name, window.dockside.host].join('');

--- a/app/client/src/components/Container.vue
+++ b/app/client/src/components/Container.vue
@@ -89,6 +89,7 @@
                            <td v-if="!isEditMode && !isPrelaunchMode">
                               <b-button v-if="router.type != 'passthru' && container.status == 1" size="sm" variant="primary" v-bind:href="makeUri(router)" :target="makeUriTarget(router)">Open</b-button>
                               <b-button v-if="router.type != 'passthru' && container.status >= 0" size="sm" variant="outline-secondary" v-on:click="copy(makeUri(router))">Copy</b-button>
+                              <b-button v-if="router.type === 'ssh' && container.status >= 0" size="sm" variant="outline-secondary" type="button" v-b-modal="'sshinfo-modal'" v-b-tooltip title="Configure SSH for Dockside">Setup</b-button>
                               ({{ container.meta.access[router.name] }} access)
                            </td>
                            <td v-else>

--- a/app/client/src/components/Container.vue
+++ b/app/client/src/components/Container.vue
@@ -320,15 +320,31 @@
             copyToClipboard(value);
          },
          makeUri(router) {
-            return router.type !== 'ssh' ? 
-              [router.https ? 'https' : 'http', '://', (router.prefixes[0] ? router.prefixes[0] : 'www'), '-', this.container.name, window.dockside.host].join('') :
-              ['ssh://',this.container.data.unixuser,'@', (router.prefixes[0] ? router.prefixes[0] : 'www'), '-', this.container.name, window.dockside.host.split(':')[0]].join('');
+            const protocol = router.https ? 'https' : 'http';
+            const prefix = router.prefixes[0] ? router.prefixes[0] : 'www';
+            const containerName = this.container.name;
+            const host = window.dockside.host;
+            
+            if (router.type !== 'ssh') {
+               return `${protocol}://${prefix}-${containerName}${host}`;
+            } else {
+               const unixuser = this.container.data.unixuser;
+               const hostname = host.split(':')[0];
+               return `ssh://${unixuser}@${prefix}-${containerName}${hostname}`;
+            }
          },
          copyUri(router) {
-            return router.type !== 'ssh' ? copyToClipboard(this.makeUri(router)) :
-               copyToClipboard(
-                 ['ssh ', this.container.data.unixuser,'@', (router.prefixes[0] ? router.prefixes[0] : 'www'), '-', this.container.name, window.dockside.host.split(':')[0]].join('')
-               );
+            if (router.type !== 'ssh') {
+               return copyToClipboard(this.makeUri(router));
+            }
+
+            const prefix = router.prefixes[0] ? router.prefixes[0] : 'www';
+            const containerName = this.container.name;
+            const host = window.dockside.host;
+            const unixuser = this.container.data.unixuser;
+            const hostname = host.split(':')[0];
+
+            return `ssh ${unixuser}@${prefix}-${containerName}${hostname}`;
          },
          makeUriTarget(router) {
             return [(router.prefixes[0] ? router.prefixes[0] : 'www'), '-', this.container.name, window.dockside.host].join('');

--- a/app/client/src/components/Container.vue
+++ b/app/client/src/components/Container.vue
@@ -320,15 +320,14 @@
             copyToClipboard(value);
          },
          makeUri(router) {
-            console.log(this.container);
             return router.type !== 'ssh' ? 
               [router.https ? 'https' : 'http', '://', (router.prefixes[0] ? router.prefixes[0] : 'www'), '-', this.container.name, window.dockside.host].join('') :
-              ['ssh://',this.container.data.unixuser,'@', (router.prefixes[0] ? router.prefixes[0] : 'www'), '-', this.container.name, window.dockside.host].join('');
+              ['ssh://',this.container.data.unixuser,'@', (router.prefixes[0] ? router.prefixes[0] : 'www'), '-', this.container.name, window.dockside.host.split(':')[0]].join('');
          },
          copyUri(router) {
             return router.type !== 'ssh' ? copyToClipboard(this.makeUri(router)) :
                copyToClipboard(
-                 ['ssh ', this.container.data.unixuser,'@', (router.prefixes[0] ? router.prefixes[0] : 'www'), '-', this.container.name, window.dockside.host].join('')
+                 ['ssh ', this.container.data.unixuser,'@', (router.prefixes[0] ? router.prefixes[0] : 'www'), '-', this.container.name, window.dockside.host.split(':')[0]].join('')
                );
          },
          makeUriTarget(router) {

--- a/app/client/src/components/SSHInfo.vue
+++ b/app/client/src/components/SSHInfo.vue
@@ -3,7 +3,7 @@
 <template>
    <b-modal id="sshinfo-modal" size="lg" v-model="showModal" @show="onModalShow" title="How to set up SSH" centered>
       <p>Download a suitable <a href="https://github.com/erebe/wstunnel" target="_blank" v-b-tooltip title="Open wstunnel in new tab"><code>wstunnel</code></a>
-      binary to your local machine and place at a location in your <code>PATH</code>:
+      binary to your local machine:
          <ul>
             <li><a href="https://storage.googleapis.com/dockside/wstunnel/wstunnel-v5.0-linux-x86_64" target="_blank">Linux amd64/x86_64 v5.0</a></li>
             <li><a href="https://storage.googleapis.com/dockside/wstunnel/wstunnel-v5.0-linux-arm64" target="_blank">Linux arm64/aarch64 v5.0</a></li>
@@ -16,6 +16,7 @@
       <p>On Unix-like systems, be sure to run <code>chmod 755 &lt;path/to&gt;/wstunnel</code> to make it executable.</p>
       <p>Copy and paste the following into your <code>~/.ssh/config</code> file:</p>
       <pre>{{ text }}</pre>
+      <p>(Comment or remove the <code>Hostname</code> line if you codefer a separate <code>known_hosts</code> record for each devtainer.)</p>
       <b-button variant="outline-success" size="sm" type="button" @click="copy(text)">Copy</b-button>
       <template #modal-footer>
          <b-button variant="primary" @click="closeModal">OK</b-button>
@@ -74,7 +75,7 @@
          },
          text() {
             return `Host ${this.sshWildcardHost}
-   ProxyCommand wstunnel --hostHeader=%n "--customHeaders=Cookie: ${this.cookies}" -L stdio:127.0.0.1:%p wss://${this.sshHost}:443
+   ProxyCommand <path/to>/wstunnel --hostHeader=%n "--customHeaders=Cookie: ${this.cookies}" -L stdio:127.0.0.1:%p wss://%n:443
    Hostname ${this.sshHost}
    ForwardAgent yes`;
          }

--- a/app/client/src/components/SSHInfo.vue
+++ b/app/client/src/components/SSHInfo.vue
@@ -63,20 +63,28 @@
                   else {
                      console.error("Error fetching authentication cookie", error);
                   }
+
+                  
                });
          }
       },
       computed: {
          sshHost() {
+            // Port number required if running on non-standard ports
             return window.location.host;         
          },
+         sshHostname() {
+            // No port number requires
+            return window.location.hostname;         
+         },
          sshWildcardHost() {
-            return 'ssh-*' + window.dockside.host;
+            // No port number requires
+            return 'ssh-*' + window.dockside.host.split(':')[0];
          },
          text() {
             return `Host ${this.sshWildcardHost}
-   ProxyCommand <path/to>/wstunnel --hostHeader=%n "--customHeaders=Cookie: ${this.cookies}" -L stdio:127.0.0.1:%p wss://%n:443
-   Hostname ${this.sshHost}
+   ProxyCommand <path/to>/wstunnel --hostHeader=%n "--customHeaders=Cookie: ${this.cookies}" -L stdio:127.0.0.1:%p wss://${this.sshHost}
+   Hostname ${this.sshHostname}
    ForwardAgent yes`;
          }
       }

--- a/app/client/src/components/SSHInfo.vue
+++ b/app/client/src/components/SSHInfo.vue
@@ -9,25 +9,30 @@
       <p>
          <ul>
             <li>Linux:
-               <a href="https://storage.googleapis.com/dockside/wstunnel/wstunnel-v5.0-linux-x86_64" target="_blank">amd64/x86_64 v5.0</a>,
-               <a href="https://storage.googleapis.com/dockside/wstunnel/wstunnel-v5.0-linux-arm64" target="_blank">arm64/aarch64 v5.0</a>,
-               <a href="https://storage.googleapis.com/dockside/wstunnel/wstunnel-v5.1-linux-armv7" target="_blank">armv7 (rPi) v5.1</a>
+               <a href="https://storage.googleapis.com/dockside/wstunnel/v6.0/wstunnel-v6.0-linux-x64" target="_blank">amd64/x86_64 v6.0</a>,
+               <a href="https://storage.googleapis.com/dockside/wstunnel/v6.0/wstunnel-v6.0-linux-arm64" target="_blank">arm64/aarch64 v6.0</a>,
+               <a href="https://storage.googleapis.com/dockside/wstunnel/v6.0/wstunnel-v6.0-linux-armv7" target="_blank">armv7 (rPi) v6.0</a>
             </li>
             <li>Windows:
-               <a href="https://storage.googleapis.com/dockside/wstunnel/wstunnel-v5.0-windows.exe" target="_blank">amd64/x86_64 v5.0</a>
+               <a href="https://storage.googleapis.com/dockside/wstunnel/v6.0/wstunnel-v6.0-windows.exe" target="_blank">amd64/x86_64 v6.0</a>
             </li>
             <li>Mac OS:
-               <a href="https://storage.googleapis.com/dockside/wstunnel/wstunnel-v5.0-macos-x86_64" target="_blank">amd64/x86-64 v5.0</a>,
-               <a href="https://storage.googleapis.com/dockside/wstunnel/wstunnel-v5.1-macos-arm64" target="_blank">arm64/aarch64 v5.1</a>
+               <a href="https://storage.googleapis.com/dockside/wstunnel/v6.0/wstunnel-v6.0-macos-x64" target="_blank">amd64/x86_64 v6.0</a>,
+               <a href="https://storage.googleapis.com/dockside/wstunnel/v6.0/wstunnel-v6.0-macos-arm64" target="_blank">arm64/aarch64 v6.0</a>
             </li>
          </ul>
       </p>
-      <p>On Unix-like systems, be sure to run <code>chmod 755 &lt;path/to&gt;/wstunnel</code> to make it executable.</p>
-      <p>Copy and paste the following into your <code>~/.ssh/config</code> file:</p>
+      <p>Copy and paste the following text into your <code>~/.ssh/config</code> file:</p>
       <pre>{{ text }}</pre>
-      <p>N.B. Comment or remove the <code>Hostname</code> line if you prefer a separate <code>known_hosts</code> record for each devtainer;
-      doing this also works around a bug in Mac OS Terminal that repeatedly complains about missing <code>known_hosts</code> entries.
-      For best results on Mac OS, use <a href="https://iterm2.com/" target="_blank" v-b-tooltip title="Open iterm2 in new tab">iTerm2</a>.</p>
+      <p>N.B.
+         <ul>
+            <li>After you paste, don't forget to edit the text to specify the correct path to your downloaded <code>wstunnel</code> binary.</li>
+            <li>On Unix-like systems, be sure to run <code>chmod a+x</code> on your <code>wstunnel</code> binary to make it executable.</li>
+            <li>Comment or remove the <code>Hostname</code> line if you prefer a separate <code>known_hosts</code> record for each devtainer;
+      doing this also works around a bug in Mac OS Terminal that repeatedly complains about missing <code>known_hosts</code> entries.</li>
+            <li>For better results on Mac OS, use <a href="https://iterm2.com/" target="_blank" v-b-tooltip title="Open iterm2 in new tab">iTerm2</a>.</li>
+         </ul>
+      </p>
       <b-button variant="outline-success" size="sm" type="button" @click="copy(text)">Copy</b-button>
       <template #modal-footer>
          <b-button variant="primary" @click="closeModal">OK</b-button>

--- a/app/client/src/components/SSHInfo.vue
+++ b/app/client/src/components/SSHInfo.vue
@@ -2,6 +2,16 @@
 
 <template>
    <b-modal id="sshinfo-modal" size="lg" v-model="showModal" @show="onModalShow" title="How to set up SSH" centered>
+      <p>Download a suitable <a href="https://github.com/erebe/wstunnel/releases" target="_blank" v-b-tooltip title="Open wstunnel in new tab"><code>wstunnel</code></a>
+      binary to your local machine and place at a location in your <code>PATH</code>.</p>
+      <p>wstunnel v5.0 binaries exist for
+         <a href="https://github.com/erebe/wstunnel/releases/download/v5.0/wstunnel-linux-x64" target="_blank">Linux x86_64</a>,
+            <a href="https://github.com/erebe/wstunnel/releases/download/v5.0/wstunnel-linux-aarch64.zip" target="_blank">Linux aarch64/arm64</a>,
+            <a href="https://github.com/erebe/wstunnel/releases/download/v5.0/wstunnel-windows-x64.zip" target="_blank">Windows x86_64</a>,
+            <a href="https://github.com/erebe/wstunnel/releases/download/v5.0/wstunnel-macos.zip" target="_blank">Mac OS x86-64</a> and
+            <a href="" target="_blank">Mac OS aarch64/arm64</a>.
+      </p>
+      <p>On Unix-like systems, be sure to run <code>chmod 755 &lt;path/to&gt;/wstunnel</code> to make it executable.</p>
       <p>Copy and paste the following into your <code>~/.ssh/config</code> file:</p>
       <pre>{{ text }}</pre>
       <b-button variant="outline-success" size="sm" type="button" @click="copy(text)">Copy</b-button>
@@ -62,7 +72,7 @@
          },
          text() {
             return `Host ${this.sshWildcardHost}
-   ProxyCommand ~/bin/wstunnel --hostHeader=%n "--customHeaders=Cookie: ${this.cookies}" -L stdio:127.0.0.1:%p wss://${this.sshHost}:443
+   ProxyCommand wstunnel --hostHeader=%n "--customHeaders=Cookie: ${this.cookies}" -L stdio:127.0.0.1:%p wss://${this.sshHost}:443
    Hostname ${this.sshHost}
    ForwardAgent yes`;
          }

--- a/app/client/src/components/SSHInfo.vue
+++ b/app/client/src/components/SSHInfo.vue
@@ -2,14 +2,16 @@
 
 <template>
    <b-modal id="sshinfo-modal" size="lg" v-model="showModal" @show="onModalShow" title="How to set up SSH" centered>
-      <p>Download a suitable <a href="https://github.com/erebe/wstunnel/releases" target="_blank" v-b-tooltip title="Open wstunnel in new tab"><code>wstunnel</code></a>
-      binary to your local machine and place at a location in your <code>PATH</code>.</p>
-      <p>wstunnel v5.0 binaries exist for
-         <a href="https://github.com/erebe/wstunnel/releases/download/v5.0/wstunnel-linux-x64" target="_blank">Linux x86_64</a>,
-            <a href="https://github.com/erebe/wstunnel/releases/download/v5.0/wstunnel-linux-aarch64.zip" target="_blank">Linux aarch64/arm64</a>,
-            <a href="https://github.com/erebe/wstunnel/releases/download/v5.0/wstunnel-windows-x64.zip" target="_blank">Windows x86_64</a>,
-            <a href="https://github.com/erebe/wstunnel/releases/download/v5.0/wstunnel-macos.zip" target="_blank">Mac OS x86-64</a> and
-            <a href="" target="_blank">Mac OS aarch64/arm64</a>.
+      <p>Download a suitable <a href="https://github.com/erebe/wstunnel" target="_blank" v-b-tooltip title="Open wstunnel in new tab"><code>wstunnel</code></a>
+      binary to your local machine and place at a location in your <code>PATH</code>:
+         <ul>
+            <li><a href="https://storage.googleapis.com/dockside/wstunnel/wstunnel-v5.0-linux-x86_64" target="_blank">Linux amd64/x86_64 v5.0</a></li>
+            <li><a href="https://storage.googleapis.com/dockside/wstunnel/wstunnel-v5.0-linux-arm64" target="_blank">Linux arm64/aarch64 v5.0</a></li>
+            <li><a href="https://storage.googleapis.com/dockside/wstunnel/wstunnel-v5.1-linux-armv7" target="_blank">Linux armv7 (rPi) v5.1</a></li>
+            <li><a href="https://storage.googleapis.com/dockside/wstunnel/wstunnel-v5.0-windows.exe" target="_blank">Windows amd64/x86_64 v5.0</a></li>
+            <li><a href="https://storage.googleapis.com/dockside/wstunnel/wstunnel-v5.0-macos-x86_64" target="_blank">Mac OS amd64/x86-64 v5.0</a></li>
+            <li><a href="https://storage.googleapis.com/dockside/wstunnel/wstunnel-v5.1-macos-arm64" target="_blank">Mac OS arm64/aarch64 v5.1</a></li>
+         </ul>
       </p>
       <p>On Unix-like systems, be sure to run <code>chmod 755 &lt;path/to&gt;/wstunnel</code> to make it executable.</p>
       <p>Copy and paste the following into your <code>~/.ssh/config</code> file:</p>

--- a/app/client/src/components/SSHInfo.vue
+++ b/app/client/src/components/SSHInfo.vue
@@ -1,0 +1,71 @@
+// https://bootstrap-vue.org/docs/components/modal#modal
+
+<template>
+   <b-modal id="sshinfo-modal" size="lg" v-model="showModal" @show="onModalShow" title="How to set up SSH" centered>
+      <p>Copy and paste the following into your <code>~/.ssh/config</code> file:</p>
+      <pre>{{ text }}</pre>
+      <b-button variant="outline-success" size="sm" type="button" @click="copy(text)">Copy</b-button>
+      <template #modal-footer>
+         <b-button variant="primary" @click="closeModal">OK</b-button>
+      </template>
+  </b-modal>
+</template>
+
+<script>
+   import copyToClipboard from '@/utilities/copy-to-clipboard';
+   import { getAuthCookies } from '@/services/container';
+
+   export default {
+      name: 'SSHInfo',
+      data() {
+         return {
+            showModal: false,
+            cookies: "<UNKNOWN>"
+         };
+      },
+      methods: {
+         openModal() {
+            this.showModal = true;
+         },
+         onModalShow() {
+            this.getCookies();
+         },
+         closeModal() {
+            this.showModal = false;
+         },
+         copy(value) {
+            copyToClipboard(value);
+         },
+         getCookies() {
+            getAuthCookies()
+               .then(data => {
+                  // Escape '%' suitably for .ssh/config file
+                  this.cookies = data.data.replace(/%/g, '%%');
+               })
+               .catch((error) => {
+                  if(error.response && error.response.status == 401) {
+                     console.log(error.response.data.msg);
+                     alert(error.response.data.msg);
+                  }
+                  else {
+                     console.error("Error fetching authentication cookie", error);
+                  }
+               });
+         }
+      },
+      computed: {
+         sshHost() {
+            return window.location.host;         
+         },
+         sshWildcardHost() {
+            return 'ssh-*' + window.dockside.host;
+         },
+         text() {
+            return `Host ${this.sshWildcardHost}
+   ProxyCommand ~/bin/wstunnel --hostHeader=%n "--customHeaders=Cookie: ${this.cookies}" -L stdio:127.0.0.1:%p wss://${this.sshHost}:443
+   Hostname ${this.sshHost}
+   ForwardAgent yes`;
+         }
+      }
+   };
+</script>

--- a/app/client/src/components/SSHInfo.vue
+++ b/app/client/src/components/SSHInfo.vue
@@ -3,20 +3,31 @@
 <template>
    <b-modal id="sshinfo-modal" size="lg" v-model="showModal" @show="onModalShow" title="How to set up SSH" centered>
       <p>Download a suitable <a href="https://github.com/erebe/wstunnel" target="_blank" v-b-tooltip title="Open wstunnel in new tab"><code>wstunnel</code></a>
-      binary to your local machine:
+      (<a href="https://github.com/erebe/wstunnel/blob/master/LICENSE" target="_blank" v-b-tooltip title="Open in new tab">LICENSE</a>)
+      binary to your local machine, from either the <a href="https://github.com/erebe/wstunnel/releases" target="_blank" v-b-tooltip title="Open wstunnel in new tab"><code>wstunnel</code> releases page</a>
+      or the Dockside public bucket (which comprises copies of officially-released binaries and binaries compiled by Dockside):</p>
+      <p>
          <ul>
-            <li><a href="https://storage.googleapis.com/dockside/wstunnel/wstunnel-v5.0-linux-x86_64" target="_blank">Linux amd64/x86_64 v5.0</a></li>
-            <li><a href="https://storage.googleapis.com/dockside/wstunnel/wstunnel-v5.0-linux-arm64" target="_blank">Linux arm64/aarch64 v5.0</a></li>
-            <li><a href="https://storage.googleapis.com/dockside/wstunnel/wstunnel-v5.1-linux-armv7" target="_blank">Linux armv7 (rPi) v5.1</a></li>
-            <li><a href="https://storage.googleapis.com/dockside/wstunnel/wstunnel-v5.0-windows.exe" target="_blank">Windows amd64/x86_64 v5.0</a></li>
-            <li><a href="https://storage.googleapis.com/dockside/wstunnel/wstunnel-v5.0-macos-x86_64" target="_blank">Mac OS amd64/x86-64 v5.0</a></li>
-            <li><a href="https://storage.googleapis.com/dockside/wstunnel/wstunnel-v5.1-macos-arm64" target="_blank">Mac OS arm64/aarch64 v5.1</a></li>
+            <li>Linux:
+               <a href="https://storage.googleapis.com/dockside/wstunnel/wstunnel-v5.0-linux-x86_64" target="_blank">amd64/x86_64 v5.0</a>,
+               <a href="https://storage.googleapis.com/dockside/wstunnel/wstunnel-v5.0-linux-arm64" target="_blank">arm64/aarch64 v5.0</a>,
+               <a href="https://storage.googleapis.com/dockside/wstunnel/wstunnel-v5.1-linux-armv7" target="_blank">armv7 (rPi) v5.1</a>
+            </li>
+            <li>Windows:
+               <a href="https://storage.googleapis.com/dockside/wstunnel/wstunnel-v5.0-windows.exe" target="_blank">amd64/x86_64 v5.0</a>
+            </li>
+            <li>Mac OS:
+               <a href="https://storage.googleapis.com/dockside/wstunnel/wstunnel-v5.0-macos-x86_64" target="_blank">amd64/x86-64 v5.0</a>,
+               <a href="https://storage.googleapis.com/dockside/wstunnel/wstunnel-v5.1-macos-arm64" target="_blank">arm64/aarch64 v5.1</a>
+            </li>
          </ul>
       </p>
       <p>On Unix-like systems, be sure to run <code>chmod 755 &lt;path/to&gt;/wstunnel</code> to make it executable.</p>
       <p>Copy and paste the following into your <code>~/.ssh/config</code> file:</p>
       <pre>{{ text }}</pre>
-      <p>(Comment or remove the <code>Hostname</code> line if you codefer a separate <code>known_hosts</code> record for each devtainer.)</p>
+      <p>N.B. Comment or remove the <code>Hostname</code> line if you prefer a separate <code>known_hosts</code> record for each devtainer;
+      doing this also works around a bug in Mac OS Terminal that repeatedly complains about missing <code>known_hosts</code> entries.
+      For best results on Mac OS, use <a href="https://iterm2.com/" target="_blank" v-b-tooltip title="Open iterm2 in new tab">iTerm2</a>.</p>
       <b-button variant="outline-success" size="sm" type="button" @click="copy(text)">Copy</b-button>
       <template #modal-footer>
          <b-button variant="primary" @click="closeModal">OK</b-button>
@@ -74,11 +85,11 @@
             return window.location.host;         
          },
          sshHostname() {
-            // No port number requires
+            // No port number required
             return window.location.hostname;         
          },
          sshWildcardHost() {
-            // No port number requires
+            // No port number required
             return 'ssh-*' + window.dockside.host.split(':')[0];
          },
          text() {

--- a/app/client/src/services/container.js
+++ b/app/client/src/services/container.js
@@ -41,4 +41,9 @@ const controlContainer = (id, cmd) => {
    return axios.get(url).then(response => response.data);
 };
 
-export { getContainers, putContainer, controlContainer, createReservationUri, getReservationLogsUri };
+const getAuthCookies = () => {
+   const url = `/getAuthCookies`;
+   return axios.get(url).then(response => response.data);
+};
+
+export { getContainers, putContainer, controlContainer, createReservationUri, getReservationLogsUri, getAuthCookies };

--- a/app/client/src/utilities/copy-to-clipboard.js
+++ b/app/client/src/utilities/copy-to-clipboard.js
@@ -1,4 +1,4 @@
-const copyToClipboard = text => {
+const copyToClipboardLegacy = text => {
    const copyTextArea = document.createElement('textarea');
 
    copyTextArea.value = text;
@@ -10,4 +10,12 @@ const copyToClipboard = text => {
    document.body.removeChild(copyTextArea);
 };
 
-export default copyToClipboard;
+export default async function copyToClipboard(text) {
+   try {
+     await navigator.clipboard.writeText(text);
+     console.log("Text copied to clipboard successfully!");
+   } catch (error) {
+     console.error("Unable to copy text to clipboard using navigator.clipboard.writeText; using legacy method", error);
+     copyToClipboardLegacy(text);
+   }
+ }

--- a/app/scripts/container/launch.sh
+++ b/app/scripts/container/launch.sh
@@ -102,10 +102,10 @@ update_ssh_authorized_keys() {
    # Set up authorized_keys, whether or not it exists
    echo "$KEYS" >$HOME/.ssh/authorized_keys
 
-   # Reset ownership and permissions for $HOME/.ssh and contents
-   log "Recursively resetting ownership and permissions for $HOME/.ssh"
-   busybox chown -R $IDE_USER:$IDE_USER $HOME/.ssh
-   busybox chmod -R u=rwX,g=rX,o=rX  $HOME/.ssh
+   log "Resetting ownership and permissions for $HOME/.ssh and $HOME/.ssh/authorized_keys"
+   busybox chown $IDE_USER:$IDE_USER $HOME/.ssh $HOME/.ssh/authorized_keys
+   busybox chmod u=rwX,g=rX,o=rX $HOME/.ssh
+   busybox chmod 600 $HOME/.ssh/authorized_keys
 }
 
 create_git_config() {

--- a/app/scripts/container/launch.sh
+++ b/app/scripts/container/launch.sh
@@ -2,24 +2,34 @@
 
 log() {
    local PID="$$"
-   local S=$(printf "%s|%15s|%5d|" "$(date +%Y-%m-%d.%H:%M:%S)" "child-init" "$PID")
+   local S=$(printf "%s|%15s|%5d|" "$(date +%Y-%m-%d.%H:%M:%S)" "launch" "$PID")
    echo "$S$1" >&2
 }
 
 which() {
    local cmd="$1"
-   for p in $(echo $PATH | tr ':' '\012'); do [ -x "$p/$cmd" ] && echo "$p/$cmd" && break; done
+   for p in $(echo $PATH | tr ':' '\012'); do [ -x "$p/$cmd" ] && echo "$p/$cmd" && return 0; done
+   return 1
 }
 
-# Expects:
-# - IDE_USER
-# 
+# Create busybox shortcut for certain commands
+for a in id; do eval "$a() { busybox $a \"\$@\"; }"; done
+
+# Assumes getent can be found in PATH
 create_user() {
+
+   # Only proceed if we are root, and the desired IDE_USER is NOT root
+   [ $(id -u) -eq 0 ] && [ "$IDE_USER" != "root" ] || return
+
+   log "Checking for user account: $IDE_USER"
+
    # Use single '=' for sh-compatibility
 
    if ! getent passwd "$IDE_USER" >/dev/null; then
+      log "Creating user account: $IDE_USER"
     
       # Use bash if available, as it may be a nicer shell experience than /bin/sh
+      local SHL
       if [ -x "/bin/bash" ]; then
          SHL="/bin/bash"
       elif [ -x "/bin/ash" ]; then
@@ -27,34 +37,84 @@ create_user() {
       else
          SHL="/bin/sh"
       fi
+
+      log "Detected shell: $SHL"
         
-      # Add the user with this shell
-      if [ -x $(which useradd) ] || [ -x $(which adduser) ]; then
-         [ -x $(which useradd) ] && useradd -l -U -m $IDE_USER -s $SHL || adduser -D $IDE_USER -s $SHL
+      # Add the user with this shell, using an available command from the image
+      if [ -x "$(which useradd)" ]; then
+         log "Running: useradd -l -U -m $IDE_USER -s $SHL"
+         useradd -l -U -m $IDE_USER -s $SHL
+      elif [ -x "$(which adduser)" ]; then
+         log "Running: adduser -D $IDE_USER -s $SHL"
+         adduser -D $IDE_USER -s $SHL
+      else
+         log "Running: busybox adduser -D $IDE_USER -s $SHL"
+         busybox adduser -D $IDE_USER -s $SHL
       fi
+   else
+      log "Found existing user account: $IDE_USER"
    fi
    
-   # Fix homedir ownership, since bind-mounts may have created it wrongly.
-   # FIXME: Implement a generalised solution to this, whereby Reservation Profile tmpfs
-   # mounts are passed by docker-event-daemon to this script
+   # Fix homedir and ~/.vscode ownership, since bind-mounts may have created it wrongly.
    local HOME=$(getent passwd $IDE_USER | cut -d':' -f6)
-   chown $IDE_USER.$IDE_USER $HOME $HOME/.vscode
-        
+
+   log "Restoring correct ownership for: $HOME"
+   busybox chown $IDE_USER:$IDE_USER $HOME
+   
+   # A generalised solution to docker issue, whereby tmpfs mountpoint ownership and mode
+   # is incorrectly set following container stop/start.
+   for p in $(busybox mount -t tmpfs | busybox awk '{print $3}' | busybox grep "^$HOME")
+   do
+      if [ -d "$p" ]; then
+         log "Restoring correct ownership and permissions for: $p"
+         busybox chown $IDE_USER:$IDE_USER $p
+         busybox chmod a+rwx,+t $p
+      fi
+   done
+
+   echo "$OWNER_DETAILS" >/tmp/dockside/user-details.json
+   local KEYS=$(echo "$OWNER_DETAILS" | jq -re '.secrets.ssh.authorized_keys[]?')
+   if [ -n "$KEYS" ]; then
+
+      # Set up .ssh folder, if it doesn't exist
+      if ! [ -d "$HOME/.ssh" ]; then
+         mkdir -p $HOME/.ssh
+         busybox chown -R $IDE_USER:$IDE_USER $HOME/.ssh
+         busybox chmod 700 $HOME/.ssh
+      fi
+
+      # Set up authorized_keys, if it doesn't exist
+      if ! [ -f $HOME/.ssh/authorized_keys ]; then
+         echo "$KEYS" >$HOME/.ssh/authorized_keys
+         busybox chown $IDE_USER:$IDE_USER $HOME/.ssh/authorized_keys
+         busybox chmod 644 $HOME/.ssh/authorized_keys
+      fi
+   fi
+
    # Set up sudo, in case that package is installed
    if ! [ -f /etc/sudoers.d/$IDE_USER ]; then
-      mkdir -p /etc/sudoers.d && echo "$IDE_USER ALL=(ALL) NOPASSWD: ALL" >/etc/sudoers.d/$IDE_USER
+      log "Setting up $IDE_USER for sudo (requires sudo package)"
+      busybox mkdir -p /etc/sudoers.d && echo "$IDE_USER ALL=(ALL) NOPASSWD: ALL" >/etc/sudoers.d/$IDE_USER
    fi
    
    # Alternatively, run echo 'root:<passwd>' | chpasswd to change to the root password and allow su to work.
    if [ -n "$ROOT_PASSWORD" ]; then
-      echo "root:$ROOT_PASSWORD" | chpasswd
+      log "Setting root password"
+      echo "root:$ROOT_PASSWORD" | busybox chpasswd
    fi
 }
 
-create_git_committer() {
+create_git_config() {
+   local HOME=$(getent passwd $IDE_USER | cut -d':' -f6)
+
+   if [ -f "$HOME/.gitconfig" ]; then
+      log "Leaving be existing ~/.gitconfig"
+      return
+   fi
+
    if [ -n "$GIT_COMMITTER_NAME" ] && [ -n "$GIT_COMMITTER_EMAIL" ]; then
-      local HOME=$(getent passwd $IDE_USER | cut -d':' -f6)
-      cat >$HOME/.gitconfig <<_EOE_ && chown $IDE_USER.$IDE_USER $HOME/.gitconfig
+      log "Creating ~/.gitconfig for $IDE_USER"
+      cat >$HOME/.gitconfig <<_EOE_ && busybox chown $IDE_USER:$IDE_USER $HOME/.gitconfig
 [user]
 name = $GIT_COMMITTER_NAME
 email = $GIT_COMMITTER_EMAIL
@@ -62,56 +122,88 @@ _EOE_
     fi
 }
 
-# Expects:
-# - IDE_USER
-# - IDE_PATH
-# 
+launch_sshd() {
+   [ -x "$(which dropbear)" ] && [ -x "$(which dropbearkey)" ] && [ -x "$(which wstunnel)" ] || return
 
-# 1. (Optionally) Create user (if needed)
-# 2. (Optionally) Create .gitconfig file
-# 3. Launch IDE watcher, in turn launching and keep running IDE.
-launch_ide() {
-   [ -n "$IDE_USER" ] || IDE_USER="root"
-   
-   # Use IDE_PATH if specified and directory exists;
-   # otherwise look for the alphanumerically latest subsubdirectory of /opt/dockside/ide
-   if [ -n "$IDE_PATH" ] && [ -d "$IDE_PATH" ]; then
-     log "Using IDE_PATH '$IDE_PATH'"
-   else
-     IDE_PATH="$(ls -d /opt/dockside/ide/*/* | tail -n 1)"
-     log "Selecting latest IDE_PATH '$IDE_PATH'"
-   fi
+   log "Launching SSHD ..."
 
+   [ -n "$SSHD_HOSTKEYS" ] || SSHD_HOSTKEYS="/tmp/dropbear"
+   [ $(id -u) -eq 0 ] && DROPBEAR_PORT=22 || DROPBEAR_PORT=2022
+   [ -d "$SSHD_HOSTKEYS" ] || mkdir -p $SSHD_HOSTKEYS
+
+   [ -f "$SSHD_HOSTKEYS/ed25519_host_key" ] || dropbearkey -t ed25519 -f $SSHD_HOSTKEYS/ed25519_host_key
+
+   log "Launching dropbear on port $DROPBEAR_PORT with host keys from $SSHD_HOSTKEYS"
+   dropbear -RE -p 127.0.0.1:$DROPBEAR_PORT -r $SSHD_HOSTKEYS/ed25519_host_key >/tmp/dockside/dropbear.log 2>&1
+
+   log "Launching wstunnel on port 2222"
+   wstunnel --server ws://0.0.0.0:2222 --restrictTo=127.0.0.1:$DROPBEAR_PORT >/tmp/dockside/wstunnel.log 2>&1 &
+}
+
+launch_theia() {
    # WARNING: DON'T BACKGROUND THESE WHILE LOOPS, OR SYSBOX RUNTIME WILL FAIL TO RUN CORRECTLY.
-   if [ $(id -u) -eq 0 ] && [ "$IDE_USER" != "root" ]; then
+   while true
+   do
 
-      echo "IDE_USER=$IDE_USER" >&2
-      create_user
-      create_git_committer
+      log "Launching and supervising the Theia IDE at $IDE_PATH"
 
-      while true
-      do
+      if [ $(id -u) -eq 0 ] && [ "$IDE_USER" != "root" ]; then
          # su will retain exported env vars and set new ones.
          # So we use 'env -i' to clear all env vars before setting just the ones needed.
+         export PATH="$_PATH"
          $IDE_PATH/bin/su $IDE_USER -c "env -i HOME=\"$(getent passwd $IDE_USER | cut -d':' -f6)\" USER=\"$IDE_USER\" IDE_PATH=\"$IDE_PATH\" $IDE_PATH/bin/sh $IDE_PATH/bin/launch-ide.sh"
-         sleep 1
-      done
-   else
-
-      IDE_USER=$(id -u -n)
-      echo "IDE_USER=$IDE_USER" >&2
-
-      create_git_committer
-
-      # Either:
-      # - Current user is root and IDE_USER is root;
-      # - Current user is not root and IDE_USER is ignored.
-      while true
-      do
+      else
+         export PATH="$_PATH"
          IDE_PATH="$IDE_PATH" $IDE_PATH/bin/sh $IDE_PATH/bin/launch-ide.sh
-         sleep 1
-      done
+      fi
+
+      sleep 1
+   done   
+}
+
+launch_all() {
+   LOG_PATH=/tmp/dockside
+   LOG=$LOG_PATH/launch.log
+
+   # Use IDE_PATH if specified and directory exists; otherwise look for the
+   # alphanumerically latest subsubdirectory of /opt/dockside/ide.
+   #
+   # N.B. Assume we can find ls and tail in the PATH
+   if [ -z "$IDE_PATH" ] || ! [ -d "$IDE_PATH" ]; then
+      IDE_PATH="$(ls -d /opt/dockside/ide/*/* | tail -n 1)"
    fi
+
+   export _PATH="$PATH"
+   PATH="$IDE_PATH/bin:$PATH"
+
+   busybox mkdir -p $LOG_PATH && busybox chmod a+rwx,+t $LOG_PATH
+
+   log "Initialised launch log ..."
+   busybox touch $LOG && busybox chmod 644 $LOG
+
+   exec 1>>$LOG
+   exec 2>>$LOG
+
+   log "Launching devtainer with: $@"
+   log "Environment:"
+   env
+
+   [ -n "$IDE_USER" ] || IDE_USER="root"
+   log "Launching with IDE_USER=$IDE_USER"
+   log "Launching with IDE_PATH=$IDE_PATH"
+
+   create_user
+   create_git_config
+   launch_sshd
+   launch_theia
+}
+
+launch_ide() {
+   if [ -z "$IDE_PATH" ] || ! [ -d "$IDE_PATH" ]; then
+      IDE_PATH="$(ls -d /opt/dockside/ide/*/* | tail -n 1)"
+   fi
+
+   $0 launch_all
 }
 
 eval "$@"

--- a/app/scripts/container/launch.sh
+++ b/app/scripts/container/launch.sh
@@ -139,14 +139,14 @@ launch_sshd() {
 
    log "Launching SSHD ..."
 
-   [ -n "$SSHD_HOSTKEYS" ] || SSHD_HOSTKEYS="/opt/dockside/host"
+   [ -n "$HOSTDATA_PATH" ] || HOSTDATA_PATH="/opt/dockside/host"
    [ $(id -u) -eq 0 ] && DROPBEAR_PORT=22 || DROPBEAR_PORT=2022
-   [ -d "$SSHD_HOSTKEYS" ] || mkdir -p $SSHD_HOSTKEYS
+   [ -d "$HOSTDATA_PATH" ] || mkdir -p $HOSTDATA_PATH
 
-   [ -f "$SSHD_HOSTKEYS/ed25519_host_key" ] || dropbearkey -t ed25519 -f $SSHD_HOSTKEYS/ed25519_host_key
+   [ -f "$HOSTDATA_PATH/ed25519_host_key" ] || dropbearkey -t ed25519 -f $HOSTDATA_PATH/ed25519_host_key
 
-   log "Launching dropbear on port $DROPBEAR_PORT with host keys from $SSHD_HOSTKEYS"
-   dropbear -RE -p 127.0.0.1:$DROPBEAR_PORT -r $SSHD_HOSTKEYS/ed25519_host_key >/tmp/dockside/dropbear.log 2>&1
+   log "Launching dropbear on port $DROPBEAR_PORT with host keys from $HOSTDATA_PATH"
+   dropbear -RE -p 127.0.0.1:$DROPBEAR_PORT -r $HOSTDATA_PATH/ed25519_host_key >/tmp/dockside/dropbear.log 2>&1
 
    log "Launching wstunnel on port 2222"
    wstunnel --server ws://0.0.0.0:2222 --restrictTo=127.0.0.1:$DROPBEAR_PORT >/tmp/dockside/wstunnel.log 2>&1 &

--- a/app/scripts/container/launch.sh
+++ b/app/scripts/container/launch.sh
@@ -59,14 +59,15 @@ create_user() {
       log "Found existing user account: $IDE_USER"
    fi
    
-   # Fix homedir and ~/.vscode ownership, since bind-mounts may have created it wrongly.
+   # Fix homedir ownership, since bind-mounts may have created it wrongly.
    local HOME=$(getent passwd $IDE_USER | cut -d':' -f6)
 
    log "Restoring correct ownership for: $HOME"
    busybox chown $IDE_USER:$IDE_USER $HOME
    
    # A generalised solution to docker issue, whereby tmpfs mountpoint ownership and mode
-   # is incorrectly set following container stop/start.
+   # is incorrectly set following container stop/start: find tmpfs inside $HOME and
+   # fixup ownership and permissions.
    for p in $(busybox mount -t tmpfs | busybox awk '{print $3}' | busybox grep "^$HOME")
    do
       if [ -d "$p" ]; then

--- a/app/scripts/container/launch.sh
+++ b/app/scripts/container/launch.sh
@@ -76,6 +76,8 @@ create_user() {
       fi
    done
 
+   # FIXME: Should we hide user details (and not dump env) from the
+   # devtainer?
    echo "$OWNER_DETAILS" >/tmp/dockside/user-details.json
 
    # Set up sudo, in case that package is installed

--- a/app/server/bin/docker-event-daemon
+++ b/app/server/bin/docker-event-daemon
@@ -20,7 +20,7 @@ use IPC::Open2;
 use Time::HiRes qw(time);
 use URI::Escape;
 
-use Util qw(cacheReadWrite flog call_socket_api run_system);
+use Util qw(cacheReadWrite flog call_socket_api run_system unique);
 use Exception;
 use Data qw($CONFIG);
 use Reservation;
@@ -59,12 +59,14 @@ sub _update {
    };
 
    my $idePath = $CONFIG->{'ide'}{'path'} || '/opt/dockside';
+   my $hostDataPath = "$idePath/host";
 
    my $newContainers;
    foreach my $c (@$newContainersFromAPI) {
 
       my $ID = substr($c->{'Id'}, 0, 12);
       my ($ideVolume) = map { $_->{'Type'} eq 'volume' ? ['volume', $_->{'Name'}] : ['bind', $_->{'Source'}] } grep { $_->{'Destination'} eq $idePath } @{$c->{'Mounts'}};
+      my ($hostDataVolume) = map { $_->{'Type'} eq 'volume' ? ['volume', $_->{'Name'}] : ['bind', $_->{'Source'}] } grep { $_->{'Destination'} eq $hostDataPath } @{$c->{'Mounts'}};
 
       $newContainers->{$ID}{'docker'} = {
          'ID' => $ID, # Short ID (for now)
@@ -84,7 +86,8 @@ sub _update {
       $newContainers->{$ID}{'inspect'} = { 
          'Networks' => $c->{'NetworkSettings'}{'Networks'},
          'Ports' => $ports,
-         'ideVolume' => $ideVolume
+         'ideVolume' => $ideVolume,
+         'hostDataVolume' => $hostDataVolume
       };
 
       # Copy the container Size from the oldContainer record if we haven't requested the Size on this run.
@@ -188,6 +191,7 @@ sub eventHandler {
                }
                catch {
                   flog("eventHandler: failed to parse event JSON '$eventJSON'");
+                  next;
                };
 
                flog(sprintf("eventHandler($events): Received event: Type=%s, Action=%s, Actor=%s", $event->{'Type'}, $event->{'Action'}, $event->{'Actor'}{'ID'}));
@@ -212,48 +216,27 @@ sub eventHandler {
                   Data::load('config.json', 'users.json', 'roles.json', 'reservations.json', 'containers.json');
 
                   my $reservations = Reservation->load({ 'containerId' => $event->{'Actor'}{'ID'} });
-                  if( @$reservations) {
-                     my $reservation = $reservations->[0];
-                     my $reservationId = $reservation->id;
-                     my $containerId = $reservation->containerId;
-
-                     flog("eventHandler: we manage reservationId=$reservationId with containerId=$containerId");
-
-                     try {
-                        if(my @Command = $reservation->ide_command()) {
-
-                           my $owner = $reservation->owner('username');
-                           my $user = User->load($owner);
-                           my $user_details = encode_json($user->details_full);
-                           
-                           flog("eventHandler: launching IDE for reservationId=$reservationId, containerId=$containerId, with command '" .
-                              join(' ', @Command) . "' for owner '$owner' and details '$user_details'");
-
-                           # TODO: Configure Profiles to support launching IDE as non-root user
-                           flog("eventHandler: launching IDE for reservationId=$reservationId, containerId=$containerId, with command: " .
-                              join(' ', @Command)
-                           );
-                           run_system($CONFIG->{'docker'}{'bin'}, 'exec', '-d', '-u', 'root',
-                              ($reservation->ide_command_env()),
-                              "--env=OWNER_DETAILS=$user_details",
-                              $event->{'Actor'}{'ID'},
-                              @Command
-                           );
-                        }
-                        else {
-                           flog("eventHandler: not launching IDE for reservationId=$reservationId, containerId=$containerId: no command");
-                        }
-                     }
-                     catch {
-                        my ($msg, $dbg) = ref($_) ? ($_->msg(), $_->dbg()) : ($_,$_);
-                        flog("eventHandler: failed to launch IDE: dbg='$dbg'; msg='$msg'");
-                     };
-                  }
-                  else {
+                  if(!@$reservations) {
                      flog("eventHandler: we don't manage containerId=$event->{'Actor'}{'ID'}");
+                     next;
                   }
-               }
 
+                  my $reservation = $reservations->[0];
+                  my $reservationId = $reservation->id;
+                  my $containerId = $reservation->containerId;
+
+                  flog("eventHandler: we manage reservationId=$reservationId with containerId=$containerId");
+
+                  try {
+                     $reservation->exec();
+                  }
+                  catch {
+                     my ($msg, $dbg) = ref($_) ? ($_->msg(), $_->dbg()) : ($_,$_);
+                     flog("eventHandler: failed to launch IDE for reservationId=$reservationId with containerId=$containerId: dbg='$dbg'; msg='$msg'");
+                  };
+               }
+            }
+            continue {
                $events++;
                $lastEventTime = time;
 
@@ -264,7 +247,6 @@ sub eventHandler {
 
             flog("eventHandler: Finished reading.");
          }
-
       }
    }
    catch {

--- a/app/server/bin/docker-event-daemon
+++ b/app/server/bin/docker-event-daemon
@@ -58,8 +58,8 @@ sub _update {
       $oldContainers = {};
    };
 
-   my $idePath = $CONFIG->{'ide'}{'path'} || '/opt/dockside';
-   my $hostDataPath = "$idePath/host";
+   my $idePath = $CONFIG->{'ide'}{'path'};
+   my $hostDataPath = $CONFIG->{'ssh'}{'path'};
 
    my $newContainers;
    foreach my $c (@$newContainersFromAPI) {

--- a/app/server/bin/docker-event-daemon
+++ b/app/server/bin/docker-event-daemon
@@ -221,11 +221,24 @@ sub eventHandler {
 
                      try {
                         if(my @Command = $reservation->ide_command()) {
+
+                           my $owner = $reservation->owner('username');
+                           my $user = User->load($owner);
+                           my $user_details = encode_json($user->details_full);
+                           
+                           flog("eventHandler: launching IDE for reservationId=$reservationId, containerId=$containerId, with command '" .
+                              join(' ', @Command) . "' for owner '$owner' and details '$user_details'");
+
                            # TODO: Configure Profiles to support launching IDE as non-root user
                            flog("eventHandler: launching IDE for reservationId=$reservationId, containerId=$containerId, with command: " .
                               join(' ', @Command)
                            );
-                           run_system($CONFIG->{'docker'}{'bin'}, 'exec', '-d', '-u', 'root', $event->{'Actor'}{'ID'}, @Command);
+                           run_system($CONFIG->{'docker'}{'bin'}, 'exec', '-d', '-u', 'root',
+                              ($reservation->ide_command_env()),
+                              "--env=OWNER_DETAILS=$user_details",
+                              $event->{'Actor'}{'ID'},
+                              @Command
+                           );
                         }
                         else {
                            flog("eventHandler: not launching IDE for reservationId=$reservationId, containerId=$containerId: no command");

--- a/app/server/example/config/config.json
+++ b/app/server/example/config/config.json
@@ -30,9 +30,6 @@
             "launch_ide"
         ]
     },
-    "ssh": {
-      "default": true
-    },
     "clientDistPath": "/home/newsnow/dockside/app/client/dist",
     "docker": {
         "bin": "/usr/bin/docker",
@@ -43,6 +40,9 @@
             "apparmor": "unspecified",
             "seccomp": "unspecified"
         }
+    },
+    "ssh": {
+      "default": true
     },
     "lxcfs": {
         "mountpoints": [

--- a/app/server/example/config/config.json
+++ b/app/server/example/config/config.json
@@ -23,23 +23,16 @@
     "ide": {
         "path": "/opt/dockside",
         "env": {
-            "SSHD_HOSTKEYS": "/etc/dropbear"
+            "SSHD_HOSTKEYS": "/opt/dockside/host",
+            "IDE_USER": "{ideUser}"
          },
          "command": [
             "/opt/dockside/launch.sh",
-            "IDE_USER='{ideUser}'",
-            "GIT_COMMITTER_NAME='{user.name}'",
-            "GIT_COMMITTER_EMAIL='{user.email}'",
             "launch_ide"
         ]
     },
     "ssh": {
-      "default": true,
-      "sharedHostKeys": {
-         "enabled": true,
-         "mountpoint": "/etc/dropbear",
-         "volume": "dockside-sshd-hostkeys"
-      }
+      "default": true
     },
     "clientDistPath": "/home/newsnow/dockside/app/client/dist",
     "docker": {

--- a/app/server/example/config/config.json
+++ b/app/server/example/config/config.json
@@ -22,13 +22,24 @@
     },
     "ide": {
         "path": "/opt/dockside",
-        "command": [
+        "env": {
+            "SSHD_HOSTKEYS": "/etc/dropbear"
+         },
+         "command": [
             "/opt/dockside/launch.sh",
             "IDE_USER='{ideUser}'",
             "GIT_COMMITTER_NAME='{user.name}'",
             "GIT_COMMITTER_EMAIL='{user.email}'",
             "launch_ide"
         ]
+    },
+    "ssh": {
+      "default": true,
+      "sharedHostKeys": {
+         "enabled": true,
+         "mountpoint": "/etc/dropbear",
+         "volume": "dockside-sshd-hostkeys"
+      }
     },
     "clientDistPath": "/home/newsnow/dockside/app/client/dist",
     "docker": {

--- a/app/server/example/config/config.json
+++ b/app/server/example/config/config.json
@@ -23,7 +23,6 @@
     "ide": {
         "path": "/opt/dockside",
         "env": {
-            "SSHD_HOSTKEYS": "/opt/dockside/host",
             "IDE_USER": "{ideUser}"
          },
          "command": [

--- a/app/server/example/config/profiles/00-dockside.json
+++ b/app/server/example/config/profiles/00-dockside.json
@@ -60,7 +60,7 @@
 
       "volume": [
          // Use this to mount encrypted ssh keys from within a per-user volume.
-         { "src": "dockside-sshkeys-{user.username}", "dst": "/home/{ideUser}/.ssh" }
+         // { "src": "dockside-sshkeys-{user.username}", "dst": "/home/{ideUser}/.ssh" }
       ]
    },
 

--- a/app/server/example/config/profiles/00-dockside.json
+++ b/app/server/example/config/profiles/00-dockside.json
@@ -45,6 +45,7 @@
          // {ideUser} will be substituted at launch-time with the user that
          // the IDE will be launched as (as per the "users" option above).
          { "dst": "/home/newsnow/.vscode", "tmpfs-size": "150M" },
+         { "dst": "/home/newsnow/.ssh", "tmpfs-size": "1M" },
 
          // These are good for most Linux distributions
          { "dst": "/tmp", "tmpfs-size": "512M" },
@@ -59,8 +60,6 @@
       ],
 
       "volume": [
-         // Use this to mount encrypted ssh keys from within a per-user volume.
-         // { "src": "dockside-sshkeys-{user.username}", "dst": "/home/{ideUser}/.ssh" }
       ]
    },
 

--- a/app/server/example/config/profiles/00-dockside.json
+++ b/app/server/example/config/profiles/00-dockside.json
@@ -60,6 +60,9 @@
       ],
 
       "volume": [
+         // Use this to mount encrypted ssh keys from within a per-user volume.
+         // N.B. Don't overwrite /home/{ideUser}/.ssh if integrated SSH server support is enabled!
+         { "src": "dockside-sshkeys-{user.username}", "dst": "/home/{ideUser}/.ssh/keys" }
       ]
    },
 

--- a/app/server/example/config/profiles/01-dockside-own-ide.json
+++ b/app/server/example/config/profiles/01-dockside-own-ide.json
@@ -60,7 +60,7 @@
 
       "volume": [
          // Use this to mount encrypted ssh keys from within a per-user volume.
-         { "src": "dockside-sshkeys-{user.username}", "dst": "/home/{ideUser}/.ssh" }
+         // { "src": "dockside-sshkeys-{user.username}", "dst": "/home/{ideUser}/.ssh" }
       ]
    },
 

--- a/app/server/example/config/profiles/01-dockside-own-ide.json
+++ b/app/server/example/config/profiles/01-dockside-own-ide.json
@@ -45,6 +45,7 @@
          // {ideUser} will be substituted at launch-time with the user that
          // the IDE will be launched as (as per the "users" option above).
          { "dst": "/home/newsnow/.vscode", "tmpfs-size": "100M" },
+         { "dst": "/home/newsnow/.ssh", "tmpfs-size": "1M" }
 
          // These are good for most Linux distributions
          { "dst": "/tmp", "tmpfs-size": "512M" },
@@ -59,8 +60,6 @@
       ],
 
       "volume": [
-         // Use this to mount encrypted ssh keys from within a per-user volume.
-         // { "src": "dockside-sshkeys-{user.username}", "dst": "/home/{ideUser}/.ssh" }
       ]
    },
 

--- a/app/server/example/config/profiles/02-dockside-io.json
+++ b/app/server/example/config/profiles/02-dockside-io.json
@@ -15,11 +15,11 @@
    "images": [ "newsnowlabs/dockside-io" ],
    "unixusers": ["dockside"],
    "mounts": {
-      "tmpfs": [],
+      "tmpfs": [
+         { "dst": "/home/{ideUser}/.ssh", "tmpfs-size": "1M" }
+      ],
       "bind": [],
-      "volume": [
-         // Use this to share encrypted ssh keys in the named volume among team members.
-          { "src": "dockside-ssh-keys-{user.username}", "dst": "/home/{ideUser}/.ssh" } ]
+      "volume": []
    },
    "runtimes": [ "runc", "runsc", "sysbox-runc" ],
    "lxcfs": true,

--- a/app/server/example/config/profiles/10-alpine.json
+++ b/app/server/example/config/profiles/10-alpine.json
@@ -19,7 +19,8 @@
       "bind": [],
       "volume": [
          // Use this to mount encrypted ssh keys from within a per-user volume.
-          { "src": "dockside-sshkeys-{user.username}", "dst": "/home/{ideUser}/.ssh" } ]
+         // { "src": "dockside-sshkeys-{user.username}", "dst": "/home/{ideUser}/.ssh" }
+      ]
    },
    "lxcfs": true,
    "dockerArgs": ["--memory=2G", "--pids-limit=4000"],

--- a/app/server/example/config/profiles/10-alpine.json
+++ b/app/server/example/config/profiles/10-alpine.json
@@ -24,6 +24,6 @@
    "lxcfs": true,
    "dockerArgs": ["--memory=2G", "--pids-limit=4000"],
    "command": [
-      "/bin/sh", "-c", "[ -x \"$(which sudo)\" ] || (apk update && apk add sudo;); sleep infinity"
+      "/bin/sh", "-c", "[ -x \"$(which sudo)\" ] || (apk update && apk add sudo curl libgcc libstdc++ bash;); sleep infinity"
    ]
 }

--- a/app/server/example/config/profiles/10-alpine.json
+++ b/app/server/example/config/profiles/10-alpine.json
@@ -15,12 +15,11 @@
    "images": [ "alpine:latest" ],
    "unixusers": ["dockside"],
    "mounts": {
-      "tmpfs": [],
+      "tmpfs": [
+         { "dst": "/home/{ideUser}/.ssh", "tmpfs-size": "1M" }
+      ],
       "bind": [],
-      "volume": [
-         // Use this to mount encrypted ssh keys from within a per-user volume.
-         // { "src": "dockside-sshkeys-{user.username}", "dst": "/home/{ideUser}/.ssh" }
-      ]
+      "volume": []
    },
    "lxcfs": true,
    "dockerArgs": ["--memory=2G", "--pids-limit=4000"],

--- a/app/server/example/config/profiles/11-debian.json
+++ b/app/server/example/config/profiles/11-debian.json
@@ -27,6 +27,6 @@
    "lxcfs": true,
    "dockerArgs": ["--memory=2G", "--pids-limit=4000"],
    "command": [
-      "/bin/sh", "-c", "[ -x \"$(which sudo)\" ] || (apt update && apt -y install sudo); sleep infinity"
+      "/bin/sh", "-c", "[ -x \"$(which sudo)\" ] || (apt update && apt -y install sudo curl); sleep infinity"
    ],
 }

--- a/app/server/example/config/profiles/11-debian.json
+++ b/app/server/example/config/profiles/11-debian.json
@@ -22,7 +22,8 @@
       "bind": [],
       "volume": [
          // Use this to mount encrypted ssh keys from within a per-user volume.
-         // { "src": "dockside-sshkeys-{user.username}", "dst": "/home/{ideUser}/.ssh" } ]
+         // { "src": "dockside-sshkeys-{user.username}", "dst": "/home/{ideUser}/.ssh" }
+      ]
    },
    "lxcfs": true,
    "dockerArgs": ["--memory=2G", "--pids-limit=4000"],

--- a/app/server/example/config/profiles/11-debian.json
+++ b/app/server/example/config/profiles/11-debian.json
@@ -18,12 +18,11 @@
    ],
    "unixusers": ["dockside"],
    "mounts": {
-      "tmpfs": [],
+      "tmpfs": [
+         { "dst": "/home/{ideUser}/.ssh", "tmpfs-size": "1M" }
+      ],
       "bind": [],
-      "volume": [
-         // Use this to mount encrypted ssh keys from within a per-user volume.
-         // { "src": "dockside-sshkeys-{user.username}", "dst": "/home/{ideUser}/.ssh" }
-      ]
+      "volume": []
    },
    "lxcfs": true,
    "dockerArgs": ["--memory=2G", "--pids-limit=4000"],

--- a/app/server/example/config/profiles/11-debian.json
+++ b/app/server/example/config/profiles/11-debian.json
@@ -22,7 +22,7 @@
       "bind": [],
       "volume": [
          // Use this to mount encrypted ssh keys from within a per-user volume.
-          { "src": "dockside-sshkeys-{user.username}", "dst": "/home/{ideUser}/.ssh" } ]
+         // { "src": "dockside-sshkeys-{user.username}", "dst": "/home/{ideUser}/.ssh" } ]
    },
    "lxcfs": true,
    "dockerArgs": ["--memory=2G", "--pids-limit=4000"],

--- a/app/server/example/config/profiles/12-redhat.json
+++ b/app/server/example/config/profiles/12-redhat.json
@@ -15,12 +15,11 @@
    "images": [ "richxsl/rhel7", "richxsl/rhel8" ],
    "unixusers": ["dockside"],
    "mounts": {
-      "tmpfs": [],
+      "tmpfs": [
+         { "dst": "/home/{ideUser}/.ssh", "tmpfs-size": "1M" }
+      ],
       "bind": [],
-      "volume": [
-         // Use this to mount encrypted ssh keys from within a per-user volume.
-         // { "src": "dockside-sshkeys-{user.username}", "dst": "/home/{ideUser}/.ssh" }
-      ]
+      "volume": []
    },
    "lxcfs": true,
    "dockerArgs": ["--memory=2G", "--pids-limit=4000"],

--- a/app/server/example/config/profiles/12-redhat.json
+++ b/app/server/example/config/profiles/12-redhat.json
@@ -19,7 +19,8 @@
       "bind": [],
       "volume": [
          // Use this to mount encrypted ssh keys from within a per-user volume.
-         // { "src": "dockside-sshkeys-{user.username}", "dst": "/home/{ideUser}/.ssh" } ]
+         // { "src": "dockside-sshkeys-{user.username}", "dst": "/home/{ideUser}/.ssh" }
+      ]
    },
    "lxcfs": true,
    "dockerArgs": ["--memory=2G", "--pids-limit=4000"],

--- a/app/server/example/config/profiles/12-redhat.json
+++ b/app/server/example/config/profiles/12-redhat.json
@@ -19,7 +19,7 @@
       "bind": [],
       "volume": [
          // Use this to mount encrypted ssh keys from within a per-user volume.
-          { "src": "dockside-sshkeys-{user.username}", "dst": "/home/{ideUser}/.ssh" } ]
+         // { "src": "dockside-sshkeys-{user.username}", "dst": "/home/{ideUser}/.ssh" } ]
    },
    "lxcfs": true,
    "dockerArgs": ["--memory=2G", "--pids-limit=4000"],

--- a/app/server/example/config/profiles/13-ubuntu.json
+++ b/app/server/example/config/profiles/13-ubuntu.json
@@ -24,12 +24,11 @@
    ],
    "unixusers": ["dockside"],
    "mounts": {
-      "tmpfs": [],
+      "tmpfs": [
+         { "dst": "/home/{ideUser}/.ssh", "tmpfs-size": "1M" }
+      ],
       "bind": [],
-      "volume": [
-         // Use this to mount encrypted ssh keys from within a per-user volume.
-         // { "src": "dockside-sshkeys-{user.username}", "dst": "/home/{ideUser}/.ssh" }
-      ]
+      "volume": []
    },
    "lxcfs": true,
    "dockerArgs": ["--memory=2G", "--pids-limit=4000"],

--- a/app/server/example/config/profiles/13-ubuntu.json
+++ b/app/server/example/config/profiles/13-ubuntu.json
@@ -33,6 +33,6 @@
    "lxcfs": true,
    "dockerArgs": ["--memory=2G", "--pids-limit=4000"],
    "command": [
-      "/bin/sh", "-c", "[ -x \"$(which sudo)\" ] || (apt update && apt -y install sudo); sleep infinity"
+      "/bin/sh", "-c", "[ -x \"$(which sudo)\" ] || (apt update && apt -y install sudo curl); sleep infinity"
    ],
 }

--- a/app/server/example/config/profiles/13-ubuntu.json
+++ b/app/server/example/config/profiles/13-ubuntu.json
@@ -28,7 +28,8 @@
       "bind": [],
       "volume": [
          // Use this to mount encrypted ssh keys from within a per-user volume.
-         // { "src": "dockside-sshkeys-{user.username}", "dst": "/home/{ideUser}/.ssh" } ]
+         // { "src": "dockside-sshkeys-{user.username}", "dst": "/home/{ideUser}/.ssh" }
+      ]
    },
    "lxcfs": true,
    "dockerArgs": ["--memory=2G", "--pids-limit=4000"],

--- a/app/server/example/config/profiles/13-ubuntu.json
+++ b/app/server/example/config/profiles/13-ubuntu.json
@@ -28,7 +28,7 @@
       "bind": [],
       "volume": [
          // Use this to mount encrypted ssh keys from within a per-user volume.
-          { "src": "dockside-sshkeys-{user.username}", "dst": "/home/{ideUser}/.ssh" } ]
+         // { "src": "dockside-sshkeys-{user.username}", "dst": "/home/{ideUser}/.ssh" } ]
    },
    "lxcfs": true,
    "dockerArgs": ["--memory=2G", "--pids-limit=4000"],

--- a/app/server/example/config/profiles/20-debian-desktop.json
+++ b/app/server/example/config/profiles/20-debian-desktop.json
@@ -25,6 +25,6 @@
    "lxcfs": true,
    "dockerArgs": [],
    "command": [
-      "/bin/sh", "-c", "[ -x \"$(which sudo)\" ] || (apt update && apt -y install sudo); /usr/local/bin/websockify --daemon --web /opt/noVNC-1.3.0/ 0.0.0.0:8080 localhost:5901; vncserver -xstartup /usr/bin/openbox-session -desktop '{container.hostname}' :1; sleep infinity"
+      "/bin/sh", "-c", "[ -x \"$(which sudo)\" ] || (apt update && apt -y install sudo curl); /usr/local/bin/websockify --daemon --web /opt/noVNC-1.3.0/ 0.0.0.0:8080 localhost:5901; vncserver -xstartup /usr/bin/openbox-session -desktop '{container.hostname}' :1; sleep infinity"
    ],
 }

--- a/app/server/example/config/profiles/20-debian-desktop.json
+++ b/app/server/example/config/profiles/20-debian-desktop.json
@@ -20,7 +20,8 @@
       "bind": [],
       "volume": [
          // Use this to share encrypted ssh keys in the named volume among team members.
-         // { "src": "dockside-ssh-keys-{user.username}", "dst": "/home/{ideUser}/.ssh" } ]
+         // { "src": "dockside-ssh-keys-{user.username}", "dst": "/home/{ideUser}/.ssh" }
+      ]
    },
    "lxcfs": true,
    "dockerArgs": [],

--- a/app/server/example/config/profiles/20-debian-desktop.json
+++ b/app/server/example/config/profiles/20-debian-desktop.json
@@ -20,7 +20,7 @@
       "bind": [],
       "volume": [
          // Use this to share encrypted ssh keys in the named volume among team members.
-          { "src": "dockside-ssh-keys-{user.username}", "dst": "/home/{ideUser}/.ssh" } ]
+         // { "src": "dockside-ssh-keys-{user.username}", "dst": "/home/{ideUser}/.ssh" } ]
    },
    "lxcfs": true,
    "dockerArgs": [],

--- a/app/server/example/config/profiles/20-debian-desktop.json
+++ b/app/server/example/config/profiles/20-debian-desktop.json
@@ -16,12 +16,11 @@
    "images": [ "newsnowlabs/dockside-debian-desktop:latest" ],
    "unixusers": ["dockside"],
    "mounts": {
-      "tmpfs": [],
+      "tmpfs": [
+         { "dst": "/home/{ideUser}/.ssh", "tmpfs-size": "1M" }
+      ],
       "bind": [],
-      "volume": [
-         // Use this to share encrypted ssh keys in the named volume among team members.
-         // { "src": "dockside-ssh-keys-{user.username}", "dst": "/home/{ideUser}/.ssh" }
-      ]
+      "volume": []
    },
    "lxcfs": true,
    "dockerArgs": [],

--- a/app/server/example/config/profiles/30-nginx.json
+++ b/app/server/example/config/profiles/30-nginx.json
@@ -15,7 +15,9 @@
    "images": [ "nginx:latest" ],
    "unixusers": ["dockside"],
    "mounts": {
-      "tmpfs": []
+      "tmpfs": [
+         { "dst": "/home/{ideUser}/.ssh", "tmpfs-size": "1M" }
+      ]
    },
    "security": {
       "apparmor": "unconfined"

--- a/app/server/example/config/profiles/90-dockside-sysbox.json
+++ b/app/server/example/config/profiles/90-dockside-sysbox.json
@@ -60,7 +60,7 @@
 
       "volume": [
          // Use this to mount encrypted ssh keys from within a per-user volume.
-         { "src": "dockside-sshkeys-{user.username}", "dst": "/home/{ideUser}/.ssh" },
+         // { "src": "dockside-sshkeys-{user.username}", "dst": "/home/{ideUser}/.ssh" },
 
          // Mount an anonymous volume at /var/lib/docker
          { "dst": "/var/lib/docker" }

--- a/app/server/example/config/profiles/90-dockside-sysbox.json
+++ b/app/server/example/config/profiles/90-dockside-sysbox.json
@@ -42,11 +42,9 @@
       // Use this to identify paths in your containers that will contain ephemeral data that will be lost
       // when the container is stopped, and which will not be duplicated in a clone operation.
       "tmpfs": [
-
-         // {ideUser} will be substituted at launch-time with the user that
-         // the IDE will be launched as (as per the "users" option above).
-         { "dst": "/home/{ideUser}/.vscode", "tmpfs-size": "100M" },
-
+         { "dst": "/home/newsnow/.vscode", "tmpfs-size": "100M" },
+         { "dst": "/home/newsnow/.ssh", "tmpfs-size": "1M" },
+   
          // These are good for most Linux distributions
          { "dst": "/tmp", "tmpfs-size": "128M" },
          { "dst": "/var/tmp", "tmpfs-size": "128M" },
@@ -59,9 +57,6 @@
       ],
 
       "volume": [
-         // Use this to mount encrypted ssh keys from within a per-user volume.
-         // { "src": "dockside-sshkeys-{user.username}", "dst": "/home/{ideUser}/.ssh" },
-
          // Mount an anonymous volume at /var/lib/docker
          { "dst": "/var/lib/docker" }
       ]

--- a/app/server/example/config/users.json
+++ b/app/server/example/config/users.json
@@ -18,9 +18,11 @@
          "images": [ "*" ],
          "runtimes": [ "*" ]
       },
-      "ssh": {
-         "authorized_keys": [],
-         "keypairs": {}
+      "secrets": {
+         "ssh": {
+            "authorized_keys": [],
+            "keypairs": {}
+         }
       }
    },
    // Example
@@ -42,9 +44,11 @@
    //       "networks": { "*": 1, "custom-network-we-want-disabled": 0 },
    //       "runtimes": { "sysbox-runc": 0, "gvisor": 1 }
    //    },
-   //    "ssh": {
-   //       "authorized_keys": [],
-   //       "keypairs": {}
+   //    "secrets": {
+   //       "ssh": {
+   //         "authorized_keys": [],
+   //          "keypairs": {}
+   //       }
    //    }
    // }
 }

--- a/app/server/example/config/users.json
+++ b/app/server/example/config/users.json
@@ -18,11 +18,8 @@
          "images": [ "*" ],
          "runtimes": [ "*" ]
       },
-      "secrets": {
-         "ssh": {
-            "authorized_keys": [],
-            "keypairs": {}
-         }
+      "ssh": {
+         "authorized_keys": []
       }
    },
    // Example
@@ -44,11 +41,8 @@
    //       "networks": { "*": 1, "custom-network-we-want-disabled": 0 },
    //       "runtimes": { "sysbox-runc": 0, "gvisor": 1 }
    //    },
-   //    "secrets": {
-   //       "ssh": {
-   //         "authorized_keys": [],
-   //          "keypairs": {}
-   //       }
+   //    "ssh": {
+   //       "authorized_keys": []
    //    }
    // }
 }

--- a/app/server/example/config/users.json
+++ b/app/server/example/config/users.json
@@ -17,6 +17,10 @@
          "auth": [ "*" ],
          "images": [ "*" ],
          "runtimes": [ "*" ]
+      },
+      "ssh": {
+         "authorized_keys": [],
+         "keypairs": {}
       }
    },
    // Example
@@ -37,6 +41,10 @@
    //       "profiles": { "admin-only-profile": 0 },
    //       "networks": { "*": 1, "custom-network-we-want-disabled": 0 },
    //       "runtimes": { "sysbox-runc": 0, "gvisor": 1 }
+   //    },
+   //    "ssh": {
+   //       "authorized_keys": [],
+   //       "keypairs": {}
    //    }
    // }
 }

--- a/app/server/lib/App.pm
+++ b/app/server/lib/App.pm
@@ -450,6 +450,25 @@ sub _handler {
          return json($r, 200, { 'status' => '200', 'data' => $containers });
       }
 
+      ######################################
+      # Load Reservations and container data
+      #
+      if( $route =~ m!^/getAuthCookies/?$! ) {
+
+         my @cookies = $User->generate_auth_cookies($parentFQDN);
+         my ($cookie) = map { s/;.*$//; $_ } grep { /Secure;$/ } @cookies;
+
+         # Append on the globalCookie (if configured in config.json)
+         if( $CONFIG->{'globalCookie'} && $CONFIG->{'globalCookie'}{'name'} && $CONFIG->{'globalCookie'}{'secret'} ) {
+            $cookie .= sprintf("; %s=%s",
+               $CONFIG->{'globalCookie'}{'name'},
+               uri_escape($CONFIG->{'globalCookie'}{'secret'})
+            );
+         }
+
+         return json($r, 200, { 'status' => '200', 'data' => $cookie });
+      }
+
       # Default: redirect to /
       return redirect($r, 302, '/');
    }

--- a/app/server/lib/Data.pm
+++ b/app/server/lib/Data.pm
@@ -76,7 +76,8 @@ my $CONFIG_FILES = {
          # Assign defaults
          $CONFIG->{'docker'}{'socket'} //= '/var/run/docker.sock';
          $CONFIG->{'docker'}{'sizes'} //= 0;
-         $CONFIG->{'ide'}{'env'}{'SSHD_HOSTKEYS'} //= '/etc/dropbear';
+         $CONFIG->{'ide'}{'path'} //= '/opt/dockside';
+         $CONFIG->{'ssh'}{'path'} //= "$CONFIG->{'ide'}{'path'}/host";
       },
       'parse' => \&parse_json
    },

--- a/app/server/lib/Data.pm
+++ b/app/server/lib/Data.pm
@@ -78,6 +78,8 @@ my $CONFIG_FILES = {
          $CONFIG->{'docker'}{'sizes'} //= 0;
          $CONFIG->{'ide'}{'path'} //= '/opt/dockside';
          $CONFIG->{'ssh'}{'path'} //= "$CONFIG->{'ide'}{'path'}/host";
+         $CONFIG->{'ssh'}{'port'} //= 2222;
+         $CONFIG->{'ssh'}{'default'} //= 1;
       },
       'parse' => \&parse_json
    },

--- a/app/server/lib/Data.pm
+++ b/app/server/lib/Data.pm
@@ -76,6 +76,7 @@ my $CONFIG_FILES = {
          # Assign defaults
          $CONFIG->{'docker'}{'socket'} //= '/var/run/docker.sock';
          $CONFIG->{'docker'}{'sizes'} //= 0;
+         $CONFIG->{'ide'}{'env'}{'SSHD_HOSTKEYS'} //= '/etc/dropbear';
       },
       'parse' => \&parse_json
    },
@@ -154,7 +155,8 @@ sub load {
    my @configFiles = @_; # Optional: list of config files to check for changes and load.
 
    if(!@configFiles) {
-      @configFiles = sort keys %$CONFIG_FILES;
+      # Ensure we load config.json first; other modules might depend upon it.
+      @configFiles = ('config.json', grep { $_ ne 'config.json' } sort keys %$CONFIG_FILES);
    }
 
    # FIXME: Throttle checking config files to 1/5s

--- a/app/server/lib/Profile.pm
+++ b/app/server/lib/Profile.pm
@@ -379,10 +379,6 @@ sub routers {
    return $_[0]->{'routers'} // [];
 }
 
-sub mounts_all {
-   return [ @{$_[0]->{'mounts'}{'tmpfs'}}, @{$_[0]->{'mounts'}{'bind'}}, @{$_[0]->{'mounts'}{'volume'}} ];
-}
-
 # Test if Profile property $type contains (or encompasses) value $value.
 # Returns 0 if not, non-0 if so.
 

--- a/app/server/lib/Profile.pm
+++ b/app/server/lib/Profile.pm
@@ -542,6 +542,14 @@ sub should_mount_ide {
    return 0;
 }
 
+sub should_mount_host_data {
+   my $self = shift;
+
+   return 1 unless exists($self->{'mountHostData'}) && $self->{'mountHostData'} == 0;
+
+   return 0;
+}
+
 sub run_docker_init {
    my $self = shift;
 

--- a/app/server/lib/Profile.pm
+++ b/app/server/lib/Profile.pm
@@ -49,7 +49,7 @@ sub versionUpgrade {
             if($routers->[$i]{'auth'}) {
                if(ref($routers->[$i]{'auth'}) ne 'ARRAY') {
                   # Set permissible array of auth modes to just the predefined default.
-                  $routers->[$i]{'auth'} = ($routers->[$i]{'type'} ne 'ide') ? [ 'user', 'developer', 'public', 'viewer', 'owner' ] : [ 'owner', 'developer' ];
+                  $routers->[$i]{'auth'} = ($routers->[$i]{'type'} =~ /^(ide|ssh)$/) ? [ 'owner', 'developer' ] : [ 'user', 'developer', 'public', 'viewer', 'owner' ];
                }
                # else allow current setting.
             }
@@ -146,7 +146,18 @@ sub new {
          # the container IDE launch script.
          "port" => 3131
       },
-   });
+   },
+   {
+      "name" => 'ssh',
+      "type" => 'ssh',
+      "auth" => ['developer', 'owner'],
+      "prefixes" => ["ssh"],
+      "domains" => ["*"],
+      "https" => {
+         "protocol" => "http", 
+         "port" => 2222
+      },
+   }   );
 
    return $self;
 }

--- a/app/server/lib/Reservation.pm
+++ b/app/server/lib/Reservation.pm
@@ -1080,6 +1080,7 @@ sub exec {
       ($reservation->ide_command_env()),
       "--env=OWNER_DETAILS=$user_details",
       "--env=AUTHORIZED_KEYS=$keys_json",
+      "--env=HOSTDATA_PATH=$CONFIG->{'ssh'}{'path'}",
       $containerId,
       @Command
    );

--- a/app/server/lib/Reservation.pm
+++ b/app/server/lib/Reservation.pm
@@ -569,7 +569,7 @@ sub cloneWithConstraints {
             'docker' => [ qw( ID Size CreatedAt Status Image ImageId Networks ) ],
             'meta' => [ qw( owner developers viewers private access description ) ],
             'profileObject' => [ qw(name routers networks runtimes) ],
-            'data' => [ qw( FQDN parentFQDN image runtime ) ],
+            'data' => [ qw( FQDN parentFQDN image runtime unixuser ) ],
             'dockerLaunchLogs' => 1
          },
          [ qw(id name owner profile status containerId) ]

--- a/app/server/lib/Reservation/Launch.pm
+++ b/app/server/lib/Reservation/Launch.pm
@@ -244,6 +244,8 @@ sub cmdline_ide_mount {
       $hostData = $INNER_DOCKERD ? ['bind', $hostDataPath] :
          $HOSTNAME ? Containers->containers->{$HOSTNAME}{'inspect'}{'hostDataVolume'} : undef;
 
+      # FIXME: Should this throw error?
+
       if($hostData) {
          push(@mounts, "--mount=type=$$hostData[0],src=$$hostData[1],dst=$hostDataPath,ro");
          flog("Reservation::createContainerReservation: for hostname '$HOSTNAME', discovered host data mount type '$$hostData[0]' src/named '$$hostData[1]'");

--- a/app/server/lib/Reservation/Launch.pm
+++ b/app/server/lib/Reservation/Launch.pm
@@ -213,6 +213,12 @@ sub cmdline_name {
    return ('--name', $self->name);
 }
 
+sub cmdline_hostname {
+   my $self = shift;
+   
+   return ('--hostname', $self->name);
+}
+
 sub cmdline_ide_mount {
    my $self = shift;
 
@@ -304,6 +310,7 @@ sub cmdline {
       $self->cmdline_ide_mount(),
       $self->cmdline_init(),
       $self->cmdline_name(),
+      $self->cmdline_hostname(),
       $self->cmdline_entrypoint(),
       $self->cmdline_image(),
       $self->cmdline_command()

--- a/app/server/lib/Reservation/Launch.pm
+++ b/app/server/lib/Reservation/Launch.pm
@@ -244,10 +244,10 @@ sub cmdline_ide_mount {
       $hostData = $INNER_DOCKERD ? ['bind', $hostDataPath] :
          $HOSTNAME ? Containers->containers->{$HOSTNAME}{'inspect'}{'hostDataVolume'} : undef;
 
-      die Exception->new( 'msg' => "Failed to locate host data volume for host '$HOSTNAME'" ) unless $hostData;
-
-      push(@mounts, "--mount=type=$$hostData[0],src=$$hostData[1],dst=$hostDataPath,ro");
-      flog("Reservation::createContainerReservation: for hostname '$HOSTNAME', discovered host data mount type '$$hostData[0]' src/named '$$hostData[1]'");
+      if($hostData) {
+         push(@mounts, "--mount=type=$$hostData[0],src=$$hostData[1],dst=$hostDataPath,ro");
+         flog("Reservation::createContainerReservation: for hostname '$HOSTNAME', discovered host data mount type '$$hostData[0]' src/named '$$hostData[1]'");
+      }
    }
 
    return @mounts;

--- a/app/server/lib/Reservation/Launch.pm
+++ b/app/server/lib/Reservation/Launch.pm
@@ -217,7 +217,7 @@ sub cmdline_ide_mount {
    my $self = shift;
 
    die Exception->new( 'msg' => "Failed to locate IDE and/or host data volumes because expected Dockside container hostname is undefined" )
-      unless $HOSTNAME;
+      unless $HOSTNAME || $INNER_DOCKERD;
 
    my $idePath = $CONFIG->{'ide'}{'path'};
    my $hostDataPath = $CONFIG->{'ssh'}{'path'};

--- a/app/server/lib/Reservation/Launch.pm
+++ b/app/server/lib/Reservation/Launch.pm
@@ -246,7 +246,7 @@ sub cmdline_ide_mount {
       flog("Reservation::createContainerReservation: for hostname '$HOSTNAME', discovered ide mount type '$$ide[0]' src/named '$$ide[1]'");
    }
 
-   if( $self->profileObject->should_mount_host_data ) {
+   if( $self->profileObject->ssh ) {
       $hostData = $INNER_DOCKERD ? ['bind', $hostDataPath] :
          $HOSTNAME ? Containers->containers->{$HOSTNAME}{'inspect'}{'hostDataVolume'} : undef;
 

--- a/app/server/lib/Reservation/Launch.pm
+++ b/app/server/lib/Reservation/Launch.pm
@@ -219,8 +219,8 @@ sub cmdline_ide_mount {
    die Exception->new( 'msg' => "Failed to locate IDE and/or host data volumes because expected Dockside container hostname is undefined" )
       unless $HOSTNAME;
 
-   my $idePath = $CONFIG->{'ide'}{'path'} || '/opt/dockside';
-   my $hostDataPath = "$idePath/host";
+   my $idePath = $CONFIG->{'ide'}{'path'};
+   my $hostDataPath = $CONFIG->{'ssh'}{'path'};
    my $ide;
    my $hostData;
 

--- a/app/server/lib/User.pm
+++ b/app/server/lib/User.pm
@@ -130,7 +130,7 @@ sub new {
       return undef unless $data->{'username'};
 
       $self = bless { 
-         %$data{ qw(username id name email role) },
+         %$data{ qw(username id name email role secrets) },
          '_permissions' => $data->{'permissions'} // {},
          '_resources' => $data->{'resources'} // {},
       }, ( ref($class) || $class );
@@ -197,6 +197,12 @@ sub details {
    my $self = shift;
 
    return { %$self{'username', 'id', 'name', 'email'} };
+}
+
+sub details_full {
+   my $self = shift;
+
+   return { %$self{'username', 'id', 'name', 'email', 'secrets'} };
 }
 
 sub password {

--- a/app/server/lib/User.pm
+++ b/app/server/lib/User.pm
@@ -217,6 +217,12 @@ sub passwordDefined {
    return defined($USER_PASSWD->{$self->username});
 }
 
+sub authorized_keys {
+   my $self = shift;
+
+   return $self->{'secrets'}{'ssh'}{'authorized_keys'} // [];
+}
+
 ################################################################################
 # MUTATORS
 # --------
@@ -826,6 +832,10 @@ sub updateContainerReservation {
 
    # and then acted upon.
    $reservation->update_network();
+
+   if( 1 ) {
+      $reservation->exec('update_ssh_authorized_keys');
+   }
 
    # Create a sanitised clone of the reservation object, before returning.
    return $self->createClientReservation($reservation);

--- a/app/server/lib/User.pm
+++ b/app/server/lib/User.pm
@@ -816,6 +816,8 @@ sub updateContainerReservation {
       die Exception->new( 'msg' => "Reservation id '$args->{'id'}' not found" );
    }
 
+   my $origReservation = Storable::dclone($reservation);
+
    # FIXME: We don't want to update data.network, when we change network; or do we?
    # FIXME: Should calling $reservation->data('network', <network>) call update_network?
    foreach my $m (qw(access viewers developers private network description)) {
@@ -833,7 +835,9 @@ sub updateContainerReservation {
    # and then acted upon.
    $reservation->update_network();
 
-   if( 1 ) {
+   # Only update devtainer authorized_keys if relevant reservation fields change.
+   if( $origReservation->meta('developers') ne $reservation->meta('developers') ||
+      $origReservation->meta('access')->{'ssh'} ne $reservation->meta('access')->{'ssh'} ) {
       $reservation->exec('update_ssh_authorized_keys');
    }
 

--- a/app/server/lib/User.pm
+++ b/app/server/lib/User.pm
@@ -130,7 +130,7 @@ sub new {
       return undef unless $data->{'username'};
 
       $self = bless { 
-         %$data{ qw(username id name email role secrets) },
+         %$data{ qw(username id name email role ssh) },
          '_permissions' => $data->{'permissions'} // {},
          '_resources' => $data->{'resources'} // {},
       }, ( ref($class) || $class );
@@ -202,7 +202,7 @@ sub details {
 sub details_full {
    my $self = shift;
 
-   return { %$self{'username', 'id', 'name', 'email', 'secrets'} };
+   return { %$self{'username', 'id', 'name', 'email', 'ssh'} };
 }
 
 sub password {
@@ -220,7 +220,7 @@ sub passwordDefined {
 sub authorized_keys {
    my $self = shift;
 
-   return $self->{'secrets'}{'ssh'}{'authorized_keys'} // [];
+   return $self->{'ssh'}{'authorized_keys'} // [];
 }
 
 ################################################################################

--- a/app/server/lib/Util.pm
+++ b/app/server/lib/Util.pm
@@ -12,6 +12,7 @@ our @EXPORT_OK = ( qw(
    YYYYMMDDHHMMSS TO_JSON
    cache cacheReadWrite cloneHash
    encrypt_password generate_auth_cookie_values validate_auth_cookie
+   unique
    ));
 
 use POSIX qw(strftime);
@@ -467,6 +468,11 @@ sub validate_auth_cookie {
 
    # Everything checks out, so return the authentication cookie data structure.
    return $l;
+}
+
+sub unique {
+   my %k = map { $_ => 1 } grep { defined($_) && $_ ne '' } @_;
+   return keys %k;
 }
 
 1;

--- a/docs/README.md
+++ b/docs/README.md
@@ -97,6 +97,7 @@ Choose from the following options:
 mkdir -p ~/.dockside && \
 docker run -it --name dockside \
   -v ~/.dockside:/data \
+  --mount=type=volume,src=dockside-ssh-hostkeys,dst=/opt/dockside/host \
   -v /var/run/docker.sock:/var/run/docker.sock \
   -p 443:443 -p 80:80 \
   --security-opt=apparmor=unconfined \
@@ -116,6 +117,7 @@ docker run -it --name dockside \
 mkdir -p ~/.dockside && \
 docker run -it --name dockside \
   -v ~/.dockside:/data \
+  --mount=type=volume,src=dockside-ssh-hostkeys,dst=/opt/dockside/host \
   -v /var/run/docker.sock:/var/run/docker.sock \
   -p 443:443 -p 80:80 \
   --security-opt=apparmor=unconfined \
@@ -133,6 +135,7 @@ docker run -it --name dockside \
 mkdir -p ~/.dockside && \
 docker run -d --name dockside \
   -v ~/.dockside:/data \
+  --mount=type=volume,src=dockside-ssh-hostkeys,dst=/opt/dockside/host \
   -v <certsdir>:/data/certs \
   -v /var/run/docker.sock:/var/run/docker.sock \
   -p 443:443 -p 80:80 \
@@ -160,6 +163,7 @@ These records are needed to tell the public DNS infrastructure that DNS requests
 mkdir -p ~/.dockside && \
 docker run -d --name dockside \
   -v ~/.dockside:/data \
+  --mount=type=volume,src=dockside-ssh-hostkeys,dst=/opt/dockside/host \
   -v /var/run/docker.sock:/var/run/docker.sock \
   -p 443:443 -p 80:80 -p 53:53/udp \
   --security-opt=apparmor=unconfined \

--- a/docs/README.md
+++ b/docs/README.md
@@ -20,6 +20,7 @@ Core features:
 - Instantly launch and clone an almost infinite multiplicity of disposable devtainers - one for each task, bug, feature or design iteration.
 - Powerful VS Code-compatible IDE.
 - HTTPS automatically provisioned for every devtainer.
+- SSH server and access automatically provisioned for every devtainer.
 - User authentication and access control to running devtainers and their web services.
 - Fine-grained user and role-based access control to devtainer functionality and underlying system resources.
 - Launch devtainers from stock Docker images, or from your own.
@@ -31,6 +32,7 @@ Benefits for developers:
 - Switch between and hand over tasks instantly. No more laborious branch switching, or committing code before it’s ready. ‘git stash’ will be a thing of the past.
 - Work from anywhere. All you need is a browser.
 - Unifying on an IDE within a team can deliver great productivity benefits for collaborative teams through improved knowledge-share, better choices and configuration of plugins and other tooling.
+- SSH access facilitates use of any terminal editor or command line tool and seamless [VS Code remote development](https://code.visualstudio.com/docs/remote/ssh) via the [Remote SSH](https://marketplace.visualstudio.com/items?itemName=ms-vscode-remote.remote-ssh) extension.
 - Develop against production databases (or production database clones) when necessary.
 
 Benefits for code reviewers:
@@ -210,6 +212,8 @@ See [Securing profiles and devtainers](securing.md)
 - [Docker-in-Dockside devtainers](extensions/runtimes/sysbox.md#sysbox-docker-in-dockside-devtainers) -- support for running devtainers using the sysbox runtime
 - [Self-contained Docker-in-Dockside](extensions/runtimes/sysbox.md#self-contained-docker-in-dockside) -- support for running Dockside using the sysbox runtime
 - [Backups](extensions/backups.md) -- strategies for backing up devtainers
+- [Integrated SSH server support](extensions/ssh.md#integrated-ssh-server-support) -- allows one-click SSH into any devtainer and auto-generated provision of `~/.ssh/authorized_keys` files
+- [Local ssh-agent support](extensions/ssh.md#local-ssh-agent-support) -- to allow use of `git` functionality of the Theia IDE (like `Git: Push` and `Git: Pull`) or other `SSH`-based commands accessible within the Theia IDE UI or terminal
 
 ## Case-study: Dockside in production at NewsNow
 

--- a/docs/extensions/ssh.md
+++ b/docs/extensions/ssh.md
@@ -1,0 +1,60 @@
+# SSH
+
+## Integrated SSH server support
+
+Dockside's SSH server support:
+
+- provisions a dropbear SSH daemon for each devtainer, allowing any authorised developer to SSH in;
+- auto-generates a `~/.ssh/authorized_keys` file for the devtainer owner and other developers with whom the devtainer is shared
+- one-click SSH to any devtainer directly from the Dockside UI
+- wstunnel helper setup instructions integrated in the Dockside UI
+- facilitates use of any terminal editor or command line tool including those that benefit from key forwarding, such as `git`
+- facilitates seamless [VS Code remote development](https://code.visualstudio.com/docs/remote/ssh) via the [Remote SSH](https://marketplace.visualstudio.com/items?itemName=ms-vscode-remote.remote-ssh) extension.
+
+Dockside enables SSH by default for all new devtainers. To disable it globally set `"ssh": { "default": false }` in `config.json`. To disable it in an individual profile, set `"ssh": false` in the profile.
+
+To configure autogeneration of devtainer `~/.ssh/authorized_keys` files, add `"ssh": { "authorized_keys": ["<key>"] }` (with a suitable public key substituted for `<key>`) for each developer user in `users.json`.
+
+Whenever a devtainer is started, or the list of developers (with whom a devtainer is shared) is modified, or the devtainer's SSH access mode is changed (from 'Devtainer owner only' to 'Devtainer developers only' or vice-versa) Dockside will populate the devtainer's `~/.ssh/authorized_keys` file with the set of public keys for all authorised developers.
+
+### SSH client setup
+
+Developers must follow the client configuration instructions, by clicking the SSH `Setup` button in the Dockside UI, prior to using SSH.
+
+These instructions will guide them through installing the [wstunnel](https://github.com/erebe/wstunnel) client helper and configuring their `~/.ssh/config` file to provide seamless SSH into their devtainers.
+
+### Notes
+
+- Since `~/.ssh/authorized_keys` can be overwritten by Dockside, SSH support is not compatible with any profiles that mount over this file (or over `~/.ssh` if the mounted filesystem contains an `authorized_keys` file) and you should take care to disable SSH in such profiles. If you make changes manually to this file on a devtainer that has SSH enabled, your changes may be lost.
+
+- Currently, Theia IDE functions that internally require an SSH client (like `Git: Push` / `Git: Pull` / the embedded Terminal) are not configured to use keys forwarded by an active `ssh -A` session. So while you can `git push` / `git pull` within an SSH terminal using forwarded keys, the IDE cannot access these keys. This limitation may be addressed in a future release. For now, read on for how to configure the Theia IDE to use keys added to a local `ssh-agent`.
+
+## Local SSH agent support
+
+To use `git` functionality of the Theia IDE (like `Git: Push` and `Git: Pull`) or other `SSH`-based commands accessible within the Theia IDE UI or terminal, you will first need to have provisioned your devtainer with the required SSH keys.
+
+When a devtainer is launched, if `ssh-agent` can be found in the launched image, then Dockside will launch `ssh-agent` in the context of the Theia IDE. This will allow IDE functions requiring SSH (like `Git: Push` and `Git: Pull`) as well as command-line tools run from within the IDE terminal (like `git` and `ssh`) to function as expected.
+
+On launch of a devtainer, you must load your SSH keys into the running agent, by running `ssh-add <path-to-key>` within a terminal, before any such IDE functions or command-line tools may be used. You only need to do this once after launching, or after stopping and starting, a devtainer.
+
+### Adding SSH keys to devtainer workspace
+
+SSH public and private key files may be dragged-and-dropped into the Theia IDE file explorer, or uploaded by right-clicking on a folder and selecting `Upload`.
+
+However, to automatically provision key files into newly-launched devtainers, configure your profiles to mount a docker volume (or bind-mount a host directory) containing your users' encrypted key files. e.g.
+
+```
+   "volume": [
+      // Use this to share encrypted ssh keys from the owner's named volume with their devtainers.
+      // N.B. Don't overwrite /home/{ideUser}/.ssh if integrated SSH server support is enabled!
+      { "src": "myprofile-sshkeys-{user.username}", "dst": "/home/{ideUser}/.ssh/keys" }
+   ]
+```
+
+(For an example of how this may be done, please see the [`dockside.json`](https://github.com/newsnowlabs/dockside/blob/main/app/server/example/config/profiles/dockside.json) profile.)
+
+> N.B.
+> 
+> 1. Although this approach means that users of a profile will have access to each others public and private key files, it will not confer access to a user's key _as long as_ the private key file is encrypted.
+> 2. It is __not recommended__ to share unencrypted SSH keys files between users in this fashion.
+> 3. If you share access to a devtainer IDE, you share access to any unencrypted keys/key files within the container. We recommend __only using encrypted key files__, running `ssh-add` to decrypt them as needed, and running `ssh-add -D` to delete stored unencrypted identities, or `ssh-add -x` to lock the agent, before sharing the IDE with untrusted users.

--- a/docs/setup.md
+++ b/docs/setup.md
@@ -58,7 +58,7 @@ The currently-supported root properties within a profile are:
 | active | must be set to `true` or the profile will be ignored | mandatory | `false` | `true` |
 | [routers](#profile-routers) | [array] preconfigured services | optional | `[]` | `[{"name": "dockside", "prefixes": [ "www" ], "domains": [ "*" ], "auth": [ "developer", "owner", "viewer", "user", "public" ], "https": { "protocol": "https", "port": 443 } }]`
 | networks | allowed docker networks | mandatory | N/A | `["bridge"]`
-| runtimes | allowed docker runtimes | optional | `["runc"]` | `["runc", "sysbox-runc"]`
+| runtimes | allowed docker runtimes | optional | `["runc"]` | `["runc", "sysbox-runc", "runcvm"]`
 | images | allowed docker images (a wildcard may be used to allow the user to specify an arbitrary element of the image string) | mandatory | N/A | `["alpine:latest","i386/alpine:latest"]` |
 | unixusers | array of the unix user account for which to run the IDE | optional | `["dockside"]` | `["john","jim"]`
 | mounts | tmpfs, bind and/or volume mounts | optional | `{}` | `{"tmpfs": [{ "dst": "/tmp","tmpfs-size": "1G"}], "volume": [{"src": "ssh-keys", "dst":"/home/mycompany/.ssh"}]}`
@@ -113,7 +113,7 @@ A user record specifies:
     - `runtimes`: Docker runtimes the user is permitted to use using, subject also to the profile (object or array)
     - `auth`: the auth/access levels the user is permitted to specify for a devtainer's router, subject also to the devtainer's profile (object or array)
 - `ssh`:
-    - `authorized_keys`: an array of strings to be written to a devtainer's `~/.ssh/authorized_keys` file when it is owned by the user or shared with the user as a developer
+    - `authorized_keys`: an array of standard ssh authorized keys strings that will be automatically written to devtainers' `~/.ssh/authorized_keys` files for devtainers owned by, or shared with, the user (as 'developer')
 
 You should add one record to `users.json`, and one record to [`passwd`](#passwords), for each registered user in your team.
 

--- a/docs/setup.md
+++ b/docs/setup.md
@@ -69,6 +69,7 @@ The currently-supported root properties within a profile are:
 | command | [array] command to run on devtainer launch | mandatory if image does not specify a long-running entrypoint or command | `[]` | `["/bin/sh", "-c", "[ -x \"$(which sudo)\" ] || (apk update && apk add sudo;); sleep infinity"]`
 | entrypoint | command with which to override image entrypoint | optional | `[]` | `["/my-entrypoint.sh"]` |
 | mountIDE | disable mounting the Dockside IDE volume (strictly for use with images, such as the Dockside image, that embed their own IDE volume) | optional | `false` | `true` |
+| ssh | whether to enable ssh access | optional | as specified in `config.json` | `true` |
 
 ### Profile routers
 
@@ -83,7 +84,7 @@ A profile may specify zero or more routers. Each router consists of:
 
 ### Router auth/access levels
 
-The available router auth/access levels are, from most to least restrictive, are:
+The available router auth/access levels, from most to least restrictive, are:
 
 - Devtainer owner only (`owner`): router may be accessed only by the devtainer owner (the user who launched the devtainer)
 - Devtainer developers only (`developer`): router may be accessed only by users named as developers of the devtainer
@@ -111,6 +112,8 @@ A user record specifies:
     - `images`: Docker images the user is permitted to launch, subject also to the profile (object or array)
     - `runtimes`: Docker runtimes the user is permitted to use using, subject also to the profile (object or array)
     - `auth`: the auth/access levels the user is permitted to specify for a devtainer's router, subject also to the devtainer's profile (object or array)
+- `ssh`:
+    - `authorized_keys`: an array of strings to be written to a devtainer's `~/.ssh/authorized_keys` file when it is owned by the user or shared with the user as a developer
 
 You should add one record to `users.json`, and one record to [`passwd`](#passwords), for each registered user in your team.
 
@@ -193,3 +196,5 @@ The `config.json` file contains global config for the Dockside instance. Not all
 - `globalCookie`: for an extra layer of security for the security-conscious, you may specify a name, domain and secret value for a global cookie which must be present before any part of Dockside, including the UI will respond to a web request; use this if you are uncomfortable with either the Dockside UI login screen, or devtainer services that may be set to 'public' to be exposed publicly
 - `lxcfs`:  is a fuse filesystem that allows processes running with docker containers to measure their own cpu, memory, and disk usage; refer to [LXCFS](extensions/lxcfs.md) for details of the LXCFS extension
 - `docker.security`: the default `apparmor` and `seccomp` security profiles (may be overriden within Dockside profiles)
+- `ssh`:
+    - `default`: a boolean indicating whether devtainers launched from profiles that do not contain an `ssh` property should have ssh access enabled (default true)

--- a/docs/usage.md
+++ b/docs/usage.md
@@ -22,6 +22,8 @@ To edit the developer and users lists, change the connected network, change the 
 
 To open a preconfigured devtainer service, click the `Open` button adjoining the service.
 
+Where SSH has been enabled, you can open an SSH terminal to a devtainer by clicking the `Open` button adjoining the SSH service. SSH support requires setup; see [Integrated SSH server support](extensions/ssh.md#integrated-ssh-server-support).
+
 > To create and customise a Profile before launching devtainers, see [Profiles](../setup/#profiles).
 
 ## Using the Dockside IDE
@@ -30,30 +32,7 @@ Dockside runs a version of the amazing open-source [Theia IDE](https://theia-ide
 
 Theia aims to be a fully VSCode-compatible IDE, provides an experience highly familiar to VSCode developers, and today seamlessly runs many VSCode extensions, which can be preinstalled or installed on demand via the Extensions tab.
 
-To use `git` functionality of the Theia IDE (like `Git: Push` and `Git: Pull`) or other `SSH`-based commands accessible within the Theia IDE UI or terminal, you will first need to have provisioned your devtainer with the required SSH keys.
-
-### SSH
-
-When a devtainer is launched, if `ssh-agent` can be found in the launched image, then Dockside will launch `ssh-agent` in the context of the Theia IDE. This will allow IDE functions requiring SSH as well as terminal command-line tools (like `git` and `ssh`) to function as expected.
-
-On launch of a devtainer, you must load your SSH keys into the running agent, by running `ssh-add <path-to-key>` within a terminal, before any such IDE functions or command-line tools may be used. You only need to do this once after launching, or after stopping and starting, a devtainer.
-
-SSH public and private key files may be dragged-and-dropped into the Theia IDE file explorer. However, to automatically provision key files into newly-launched devtainers, you may configure the relevant profile to mount a docker volume (or bind-mount a host directory) containing your users' encrypted key files. e.g.
-
-```
-   "volume": [
-      // Use this to share encrypted ssh keys in the named volume among team members.
-      { "src": "myprofile-ssh-keys", "dst": "/home/newsnow/.ssh" }
-   ]
-```
-
-(For an example of how this may be done, please see the [`dockside.json`](https://github.com/newsnowlabs/dockside/blob/main/app/server/example/config/profiles/dockside.json) profile.)
-
-> N.B.
-> 
-> 1. Although this approach means that users of a profile will have access to each others public and private key files, it will not confer access to a user's key _as long as_ the private key file is encrypted.
-> 2. It is __not recommended__ to share unencrypted SSH keys files between users in this fashion.
-> 3. If you share access to a devtainer IDE, you share access to any unencrypted keys/key files within the container. We recommend __only using encrypted key files__, running `ssh-add` to decrypt them as needed, and running `ssh-add -D` to delete stored unencrypted identities, or `ssh-add -x` to lock the agent, before sharing the IDE with untrusted users.
+To use `git` functionality of the Theia IDE (like `Git: Push` and `Git: Pull`) or other `SSH`-based commands accessible within the Theia IDE UI or terminal, you will first need to have provisioned your devtainer with the required SSH keys. See [SSH: Local ssh-agent support](extensions/ssh.md#local-ssh-agent-support).
 
 ### Root access within Devtainers
 

--- a/ide/theia/1.40.0/bin/launch-ide.sh
+++ b/ide/theia/1.40.0/bin/launch-ide.sh
@@ -6,7 +6,7 @@
 
 log() {
   local PID="$$"
-  local S=$(printf "%s|%15s|%5d|" "$(date +%Y-%m-%d.%H:%M:%S)" "child-ide" "$PID")
+  local S=$(printf "%s|%15s|%5d|" "$(date +%Y-%m-%d.%H:%M:%S)" "theia" "$PID")
   echo "$S$1" >&2
 }
 
@@ -15,7 +15,7 @@ which() {
   for p in $(echo $PATH | tr ':' '\012'); do [ -x "$p/$cmd" ] && echo "$p/$cmd" && break; done
 }
 
-LOG=/tmp/theia.log
+LOG=/tmp/dockside/theia.log
 
 log "Creating logfile '$LOG' ..."
 touch $LOG && chmod 666 $LOG
@@ -28,7 +28,7 @@ eval "$@"
 
 log "Launching IDE from IDE_PATH='$IDE_PATH' ..."
 
-log "Backing up and overriding PATH ..."
+log "Backing up and overriding PATH=$PATH ..."
 export _PATH="$PATH"
 export PATH="$IDE_PATH/bin:$PATH"
 
@@ -38,11 +38,6 @@ if [ -x $(which ssh-agent) ] && ! pgrep ssh-agent >/dev/null; then
    log "Found ssh-agent binary but no running agent, so launching it ..."
    eval $($(which ssh-agent))
 fi
-
-mkdir -p /tmp/dropbear
-dropbearkey -t ed25519 -f /tmp/dropbear/dropbear_ed25519_host_key
-dropbear -R -p 127.0.0.1:2223 -r /tmp/dropbear/dropbear_ed25519_host_key # >/tmp/dockside/dropbear.log 2>&1
-wstunnel --server ws://0.0.0.0:2222 --restrictTo=127.0.0.1:2223 & # >/tmp/dockside/wstunnel.log 2>&1
 
 # See https://github.com/eclipse-theia/theia/blob/master/CHANGELOG.md under v0.13.0
 # 

--- a/ide/theia/1.40.0/bin/launch-ide.sh
+++ b/ide/theia/1.40.0/bin/launch-ide.sh
@@ -30,7 +30,7 @@ log "Launching IDE from IDE_PATH='$IDE_PATH' ..."
 
 log "Backing up and overriding PATH ..."
 export _PATH="$PATH"
-export PATH="$IDE_PATH/theia/bin:$PATH"
+export PATH="$IDE_PATH/bin:$PATH"
 
 # Run ssh-agent if available, but not already running.
 log "Checking for ssh-agent ..."
@@ -38,6 +38,11 @@ if [ -x $(which ssh-agent) ] && ! pgrep ssh-agent >/dev/null; then
    log "Found ssh-agent binary but no running agent, so launching it ..."
    eval $($(which ssh-agent))
 fi
+
+mkdir -p /tmp/dropbear
+dropbearkey -t ed25519 -f /tmp/dropbear/dropbear_ed25519_host_key
+dropbear -R -p 127.0.0.1:2223 -r /tmp/dropbear/dropbear_ed25519_host_key # >/tmp/dockside/dropbear.log 2>&1
+wstunnel --server ws://0.0.0.0:2222 --restrictTo=127.0.0.1:2223 & # >/tmp/dockside/wstunnel.log 2>&1
 
 # See https://github.com/eclipse-theia/theia/blob/master/CHANGELOG.md under v0.13.0
 # 


### PR DESCRIPTION
Here is a pull request for allowing fully-managed ssh access to devtainers.

There's a few little FIXMEs in the branch that should be resolved, but it will be easier to discuss these in the context of the whole branch:

1. Should a devtainer owner's details (name, email, ssh secrets) be exposed in a devtainer's filesystem (in `/tmp/dockside` launch logs) as a matter of course. In practice all of these details may be written to the filesystem (`.gitconfig`, `.ssh/authorized_keys`) but there may be exceptional cases where this is not needed or desired.
2. The patched-dockside requires a volume or bind mount at `/opt/dockside/host` on the Dockside container. An anonymous volume will be mounted there automatically (thanks to `VOLUME` directive in the `Dockerfile`). This volume is used to store an sshd host key that all devtainers can share. It will be identified by Dockside and remounted read-only into each devtainer.
   1. If however when Dockside is launching the volume is _not_ read-write, and there is no host key, should Dockside throw an error? That's the current logic, but there may be edge cases, such as launching Dockside in Dockside, which should be supported.
   2. If when launching a new devtainer, Dockside cannot identify a bind-mount or volume at `/opt/dockside/host`, should it throw an error or continue to launch the devtainer but without the mount? Are there any edge-cases?
3. `launch.sh` compatibility: is it possible for a new devtainer to be launched with an older `launch.sh` or vice-versa, and if so does everything work or fail gracefully? Devtainers should consistently launch, especially on Dockside upgrade but also where possible on downgrade (e.g. when launching a devtainer we would not want, the new `wstunnel` or `dropbear` binaries not to be found, or if not found for this not to be handled gracefully).