### PR TITLE
Add 'none' pseudo-IDE for SSH-only devtainers

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -48,14 +48,6 @@ elif [ "${TARGETPLATFORM}" = "linux/arm64" ]; then
     WSTUNNEL_BINARY="https://github.com/erebe/wstunnel/releases/download/v${WSTUNNEL_VERSION}/wstunnel_${WSTUNNEL_VERSION}_linux_arm64.tar.gz"
     OPENVSCODE_VERSION="1.109.5"
     OPENVSCODE_BINARY="https://github.com/gitpod-io/openvscode-server/releases/download/openvscode-server-v$OPENVSCODE_VERSION/openvscode-server-v$OPENVSCODE_VERSION-linux-arm64.tar.gz"
-elif [ "${TARGETPLATFORM}" = "linux/arm/v7" ]; then
-    THEIA_VERSION="1.35.0"
-    THEIA_BUILD_EXTRA_PACKAGES="ripgrep"
-    WSTUNNEL_V6_BINARY="https://storage.googleapis.com/dockside/wstunnel/v6.0/wstunnel-v6.0-linux-armv7"
-    WSTUNNEL_BINARY="https://github.com/erebe/wstunnel/releases/download/v${WSTUNNEL_VERSION}/wstunnel_${WSTUNNEL_VERSION}_linux_armv7.tar.gz"
-    OPENVSCODE_VERSION="1.109.5"
-    OPENVSCODE_BINARY="https://github.com/gitpod-io/openvscode-server/releases/download/openvscode-server-v$OPENVSCODE_VERSION/openvscode-server-v$OPENVSCODE_VERSION-linux-armhf.tar.gz"
-    OPENVSCODE_BUILD_DEBIAN_EXTRA_PACKAGES="libatomic1"
 else
     echo "Build error: Unsupported architecture '$TARGETPLATFORM'" >&2;
     exit 1;
@@ -172,15 +164,6 @@ RUN cd $THEIA_BUILD_PATH && \
 FROM theia-clean AS theia-ide
 
 ARG OPT_PATH
-
-# The version of rg installed by the Theia build on linux/arm/v7
-# depends on libs that are not available on Alpine on this platform.
-# Workaround this by overwriting it with Alpine's own rg.
-# ARG TARGETPLATFORM
-RUN if [ "$TARGETPLATFORM" = "linux/arm/v7" ]; then \
-      apk add --no-cache ripgrep; \
-      cp $(which rg) $(find $THEIA_BUILD_PATH -name rg); \
-    fi
 
 RUN apk add --no-cache file patchelf coreutils findutils
 
@@ -665,6 +648,18 @@ RUN curl -fsSL https://claude.ai/install.sh | bash
 # `claude` is on PATH in shells opened against this image (terminals, SSH, etc.).
 RUN grep -qF 'export PATH="$HOME/.local/bin:$PATH"' $HOME/.bashrc 2>/dev/null || \
     echo 'export PATH="$HOME/.local/bin:$PATH"' >> $HOME/.bashrc
+
+# depot's installer doesn't touch shell rc files either (same as claude's above) - it
+# just prints a manual-setup suggestion if `depot` isn't on PATH afterwards. Apply that
+# directly, following the same convention as $HOME/.local/bin above. Each append is
+# parenthesized so it short-circuits independently of the others; without the parens,
+# `&&`/`||` share one precedence level left-to-right, so a later `|| echo` would mask a
+# failed install instead of the RUN failing outright.
+RUN curl -L https://depot.dev/install-cli.sh | sh && \
+    (grep -qF 'export DEPOT_INSTALL_DIR="$HOME/.depot/bin"' $HOME/.bashrc 2>/dev/null || \
+     echo 'export DEPOT_INSTALL_DIR="$HOME/.depot/bin"' >> $HOME/.bashrc) && \
+    (grep -qF 'export PATH="$DEPOT_INSTALL_DIR:$PATH"' $HOME/.bashrc 2>/dev/null || \
+     echo 'export PATH="$DEPOT_INSTALL_DIR:$PATH"' >> $HOME/.bashrc)
 
 # Restore root as the effective runtime user, matching the base dockside stage:
 # entrypoint.sh requires root (sets up /etc/service, fixes ownership under /data, etc.)

--- a/app/client/src/components/Container.vue
+++ b/app/client/src/components/Container.vue
@@ -66,7 +66,7 @@
                            <td v-if="!isEditMode && !isPrelaunchMode">{{ container.meta.IDE }}</td>
                            <td v-else>
                               <select class="form-control" v-model="form.IDE" :disabled="IDEs.length <= 1">
-                                 <option v-for="IDE in IDEs" v-bind:key="IDE">{{ IDE }}</option>
+                                 <option v-for="IDE in IDEs" v-bind:key="IDE" v-bind:value="IDE">{{ ideLabel(IDE) }}</option>
                               </select>
                            </td>
                         </tr>
@@ -131,8 +131,8 @@
                         <tr v-for="(router, index) in routers" v-bind:key="index" v-bind:class="{'list-item':true}">
                            <th>&#8674;&nbsp;{{ router.name }} </th>
                            <td v-if="!isEditMode && !isPrelaunchMode">
-                              <b-button v-if="router.type != 'passthru' && container.status == 1" size="sm" variant="primary" v-bind:href="makeUri(router)" :target="makeUriTarget(router)">Open</b-button>
-                              <b-button v-if="router.type != 'passthru' && container.status == 1" size="sm" variant="outline-secondary" v-on:click="copyUri(router)">Copy</b-button>
+                              <b-button v-if="router.type != 'passthru' && container.status == 1 && !(router.type === 'ide' && container.meta.IDE === 'none')" size="sm" variant="primary" v-bind:href="makeUri(router)" :target="makeUriTarget(router)">Open</b-button>
+                              <b-button v-if="router.type != 'passthru' && container.status == 1 && !(router.type === 'ide' && container.meta.IDE === 'none')" size="sm" variant="outline-secondary" v-on:click="copyUri(router)">Copy</b-button>
                               <b-button v-if="router.type === 'ssh' && container.status >= 0" size="sm" variant="outline-secondary" type="button" v-b-modal="'sshinfo-modal'" v-b-tooltip title="Configure SSH for Dockside">Setup</b-button>
                               ({{ container.meta.access[router.name] }} access)
                            </td>
@@ -393,6 +393,9 @@
          ...mapActions([
             'updateSelectedContainerMode'
          ]),
+         ideLabel(IDE) {
+            return IDE === 'none' ? 'No IDE (SSH only)' : IDE;
+         },
          initialiseForm() {
             // We need to initialise the form when:
             // 1. Component created for launching

--- a/app/client/src/components/SSHInfo.vue
+++ b/app/client/src/components/SSHInfo.vue
@@ -69,8 +69,7 @@
             <ul>
                <li>Linux:
                   <a href="https://storage.googleapis.com/dockside/wstunnel/v6.0/wstunnel-v6.0-linux-x64" target="_blank">amd64/x86_64 v6.0</a>,
-                  <a href="https://storage.googleapis.com/dockside/wstunnel/v6.0/wstunnel-v6.0-linux-arm64" target="_blank">arm64/aarch64 v6.0</a>,
-                  <a href="https://storage.googleapis.com/dockside/wstunnel/v6.0/wstunnel-v6.0-linux-armv7" target="_blank">armv7 (rPi) v6.0</a>
+                  <a href="https://storage.googleapis.com/dockside/wstunnel/v6.0/wstunnel-v6.0-linux-arm64" target="_blank">arm64/aarch64 v6.0</a>
                </li>
                <li>Windows:
                   <a href="https://storage.googleapis.com/dockside/wstunnel/v6.0/wstunnel-v6.0-windows.exe" target="_blank">amd64/x86_64 v6.0</a>

--- a/app/client/src/components/admin/ResourcesEditor.vue
+++ b/app/client/src/components/admin/ResourcesEditor.vue
@@ -67,7 +67,7 @@
                networks: ['*', ...(hr.networks  || [])],
                auth:     ['*', ...(hr.authModes || DEFAULT_AUTH_MODES)],
                images:   ['*'],
-               IDEs:     ['*', ...(hr.IDEs      || [])],
+               IDEs:     ['*', 'none', ...(hr.IDEs || [])],
             };
          },
       },

--- a/app/scripts/container/launch.sh
+++ b/app/scripts/container/launch.sh
@@ -739,6 +739,9 @@ restart_ide() {
    # Match IDE strings of form openvscode/<version> or <theia>/<version>
    # where <version> is a specific version string or the string 'latest'
    case "$IDE" in
+      none)
+         log "IDE is 'none': no IDE to launch."
+         ;;
       openvscode/*)
          launch_openvscode
          ;;

--- a/app/server/lib/Data.pm
+++ b/app/server/lib/Data.pm
@@ -41,6 +41,8 @@ sub parse_json ($json) {
 }
 
 sub valid_ide_name ($ide) {
+   # 'none' is a pseudo-IDE meaning "no IDE" (SSH-only) - see Profile::applyDefaultsAndFilters.
+   return 1 if defined($ide) && $ide eq 'none';
    return defined($ide) && $ide =~ m!\A[^./\0][^/\0]*/[^./\0][^/\0]*\z!;
 }
 
@@ -89,6 +91,7 @@ $CONFIG_FILES = {
          $CONFIG->{'ide'}{'path'} //= '/opt/dockside';
          $CONFIG->{'ide'}{'subPath'} //= 'ide';
          $CONFIG->{'ide'}{'fullPath'} //= "$CONFIG->{'ide'}{'path'}/$CONFIG->{'ide'}{'subPath'}";
+         $CONFIG->{'ide'}{'default'} //= 1;
 
          $CONFIG->{'ssh'}{'path'} //= "$CONFIG->{'ide'}{'path'}/host";
          $CONFIG->{'ssh'}{'port'} //= 2222;    # in-container wstunnel v6 listen port

--- a/app/server/lib/Profile.pm
+++ b/app/server/lib/Profile.pm
@@ -106,9 +106,32 @@ sub applyDefaultsAndFilters ($self) {
    $self->{'networks'} = ["*"] unless defined($self->{'networks'});
    $self->{'networks'} = $applyFilters->('network', \@hostNetworks);
 
-   # IDE
+   # IDE (global on/off switch)
+   # If unspecified in profile, set to value of config.json ide.default, or true.
+   $self->{'ide'} //= $CONFIG->{'ide'}{'default'} // 1;
+
+   # IDE (choice of IDE, or 'none' for no IDE / SSH-only)
    $self->{'IDEs'} = ["*"] unless defined($self->{'IDEs'});
-   $self->{'IDEs'} = $applyFilters->('IDE', $HOSTINFO->{'IDEs'}, 'tag/version');
+
+   # Exact-match only: '*' (or any wildcard pattern) never implies 'none' - a profile
+   # author must opt in to offering 'none' explicitly, since it is never a real,
+   # host-installed IDE for the wildcard filter below to match it against.
+   my $noneOffered = scalar( grep { $_ eq 'none' } @{$self->{'IDEs'}} );
+
+   if( ! $self->{'ide'} ) {
+      # IDE subsystem switched off entirely for this profile (config.json ide.default,
+      # or a profile-level "ide": false override): 'none' is the only possible value,
+      # regardless of whatever real IDE patterns the profile's own IDEs list names.
+      $self->{'IDEs'} = ['none'];
+   }
+   else {
+      $self->{'IDEs'} = $applyFilters->('IDE', $HOSTINFO->{'IDEs'}, 'tag/version');
+
+      # Append 'none' *after* the sort, so it is unconditionally last - this guarantees
+      # default_IDE() and the Vue client's naive IDEs[0] selection never pick 'none'
+      # unless it is the only element.
+      push(@{$self->{'IDEs'}}, 'none') if $noneOffered;
+   }
 
    # Runtimes
    $self->{'runtimes'} = ["*"] unless defined($self->{'runtimes'});
@@ -188,8 +211,17 @@ sub new ($class, $data, $validated = 0) {
    # TODO: Should defaults and filters be separated?
    $self->applyDefaultsAndFilters();
 
-   # Add the IDE router, if none specified
-   if( ! grep { $_->{'type'} eq 'ide' } @{$self->{'routers'}} ) {
+   # Add the IDE router, if none specified - unless the profile's resolved IDEs is
+   # non-empty and consists entirely of 'none' (i.e. no real IDE is ever offered, so
+   # there is nothing to proxy to). Otherwise, a profile offering a genuine choice
+   # between 'none' and a real IDE still gets the router: routers cannot be added to
+   # an existing reservation post-launch (see Reservation::profile()/Profile->load()),
+   # so it must exist now in case a user picks 'none' today but a real IDE later.
+   # (A profile whose resolved IDEs is empty - no host IDE installed, no 'none'
+   # declared - still gets a router too, unchanged from prior behaviour.)
+   my @resolvedIDEs = @{ $self->{'IDEs'} // [] };
+   my $isNoneOnly = @resolvedIDEs && ! grep { $_ ne 'none' } @resolvedIDEs;
+   if( ! $isNoneOnly && ! grep { $_->{'type'} eq 'ide' } @{$self->{'routers'}} ) {
       push(@{$self->{'routers'}}, {
          "name" => 'ide',
          "type" => 'ide',
@@ -258,6 +290,7 @@ sub validate ($self) {
          metadata
          lxcfs=b
          ssh=b
+         ide=b
          security=%
          gitURLs=@
          IDEs=@
@@ -539,6 +572,12 @@ sub options ($self) {
 
 sub ssh ($self) {
    return $self->{'ssh'};
+}
+
+# N.B. distinct from Reservation's own '{ide}' key (the launch-command config copied
+# from $CONFIG->{'ide'} - path/command/env), which lives on a different blessed object.
+sub ide ($self) {
+   return $self->{'ide'};
 }
 
 # Test if Profile property $type contains (or encompasses) value $value.

--- a/app/server/lib/User.pm
+++ b/app/server/lib/User.pm
@@ -578,6 +578,21 @@ sub reservation ($self, $arg = undef) {
 #
 
 # Private method.
+# Builds the exception message for a denied set() call. For 'IDE' specifically, lists
+# the caller's currently-permitted choices (profile/role/user-constrained), including
+# 'none' where applicable, instead of a generic message with no actionable detail.
+sub _set_denied_msg ($self, $reservation, $property, $value) {
+   if( $property eq 'IDE' && $reservation->profileObject ) {
+      my $profileObject = $reservation->profileObject->cloneWithConstraints($self->derivedResourceConstraints);
+      my @choices = @{$profileObject->IDEs};
+      return @choices
+         ? "You have no permission to set 'IDE' to '$value' in this reservation (allowed: " . join(', ', @choices) . ")"
+         : "You have no permission to set 'IDE' to '$value' in this reservation (no IDE choices are currently permitted)";
+   }
+   return "You have no permissions to set '$property' to '$value' in this reservation";
+}
+
+# Private method.
 # Returns truthy if user is authorised to set $property to $value
 # Returns falsey if not.
 sub set ($self, $reservation, $property, $value = '') {
@@ -901,8 +916,8 @@ sub updateContainerReservation ($self, $args) {
    # Update metadata fields if they are defined in the arguments
    foreach my $m (qw( access viewers developers private network description IDE )) {
       if(defined($args->{$m})) {
-         $self->set($reservation, $m, $args->{$m}) || 
-            die Exception->new( 'msg' => "You have no permissions to set '$m' to '$args->{$m}' in this reservation" );
+         $self->set($reservation, $m, $args->{$m}) ||
+            die Exception->new( 'msg' => $self->_set_denied_msg($reservation, $m, $args->{$m}) );
       }
    }
 
@@ -991,8 +1006,8 @@ sub createContainerReservation ($self, $args) {
    );
 
    foreach my $m (qw( profile image runtime network unixuser access viewers developers private description gitURL IDE options )) {
-      $self->set($reservation, $m, $args->{$m}) || 
-         die Exception->new( 'msg' => "You have no permissions to set '$m' to '$args->{$m}' in this reservation" );
+      $self->set($reservation, $m, $args->{$m}) ||
+         die Exception->new( 'msg' => $self->_set_denied_msg($reservation, $m, $args->{$m}) );
    }
 
    $reservation->data('runningIDE', $reservation->meta('IDE'));

--- a/build/build.sh
+++ b/build/build.sh
@@ -4,7 +4,7 @@ REPO="newsnowlabs/dockside"
 DOCKERFILE="Dockerfile"
 TAG_DATE="$(date -u +%Y%m%d%H%M%S)"
 BUILDER=buildkit
-PLATFORMS_DEFAULT_DEPOT="linux/amd64,linux/arm64,linux/arm/v7"
+PLATFORMS_DEFAULT_DEPOT="linux/amd64,linux/arm64"
 DIR=$(dirname "$(realpath "${BASH_SOURCE[0]}")")/..
 
 usage() {

--- a/build/development/dot-theia/tasks.json
+++ b/build/development/dot-theia/tasks.json
@@ -14,7 +14,7 @@
          "type": "pickString",
          "id": "platforms",
          "description": "Select the platform(s)",
-         "options": ["linux/amd64", "linux/arm64", "linux/arm/v7", "linux/amd64,linux/arm64", "linux/amd64,linux/arm64,linux/arm/v7"],
+         "options": ["linux/amd64", "linux/arm64", "linux/amd64,linux/arm64"],
          "default": "linux/amd64"
       },
       {

--- a/build/development/make-bundelf-bundle.sh
+++ b/build/development/make-bundelf-bundle.sh
@@ -54,8 +54,8 @@ BUNDELF_EXEC_PATH="${BUNDELF_EXEC_PATH:-$BUNDELF_CODE_PATH}"
 BUNDELF_LIBPATH_TYPE="${BUNDELF_LIBPATH_TYPE:-relative}"
 
 # Determine LD filepath, which is architecture-dependent:
-# e.g. ld-musl-aarch64.so.1 (linux/arm64), ld-musl-armhf.so.1 (linux/arm/v7), ld-musl-x86_64.so.1 (linux/amd64)
-#   or ld-linux-aarch64.so.1 (linux/arm64), ld-linux-armhf.so.3 (linux/arm/v7), ld-linux-x86-64.so.2 (linux/amd64)
+# e.g. ld-musl-aarch64.so.1 (linux/arm64), ld-musl-x86_64.so.1 (linux/amd64)
+#   or ld-linux-aarch64.so.1 (linux/arm64), ld-linux-x86-64.so.2 (linux/amd64)
 LD_PATH=$(ls -1 /lib/ld-musl-* /lib/*-linux-*/ld-linux-*.so.* 2>/dev/null | head -n 1)
 if [ -z "$LD_PATH" ]; then
   echo "ERROR: No dynamic linker found in /lib (ld-musl-* or ld-linux-*.so.*)" >&2

--- a/cli/dockside
+++ b/cli/dockside
@@ -1704,7 +1704,9 @@ def _add_shared_fields(p):
     p.add_argument('--network', metavar='NETWORK',
                    help='Docker network name')
     p.add_argument('--ide', metavar='IDE',
-                   help='IDE to use (e.g. theia/latest, openvscode/latest)')
+                   help="IDE to use (e.g. theia/latest, openvscode/latest), or 'none' for "
+                        "SSH-only (no IDE) - only valid if the profile, your user, and your "
+                        "role all permit it")
     p.add_argument('--description', metavar='TEXT',
                    help='Short description of the devtainer')
     p.add_argument('--viewers', metavar='LIST',

--- a/docs/README.md
+++ b/docs/README.md
@@ -105,14 +105,14 @@ Advanced features:
 
 ## Host requirements
 
-Dockside is supported on Intel (amd64/x86), Apple M1/M2 (arm64) and Raspberry Pi (arm/v7) hardware platforms, via a multiarch Docker image
-that contains native binary implementations of Dockside for all three architectures.
+Dockside is supported on Intel (amd64/x86) and arm64 (Apple M1-5, Raspberry Pi 64-bit) hardware platforms, via a multiarch Docker image
+that contains native binary implementations of Dockside for both architectures.
 
 Dockside is tested on:
 - Intel (amd64/x86) platforms running Debian Linux and [Docker Engine](https://docs.docker.com/engine/install/) (via the `docker-ce` package suite)
-- MacOS (amd64/x86 and Apple Mac M1) running [Docker Desktop](https://docs.docker.com/get-docker/)
+- MacOS (amd64/x86 and Apple M1-5) running [Docker Desktop](https://docs.docker.com/get-docker/)
 - Intel Windows 10 running [Docker Desktop](https://docs.docker.com/get-docker/)
-- Raspberry Pi (arm/v7) running Raspbian Linux and [Docker Engine](https://docs.docker.com/engine/install/) (via the `docker-ce` package suite)
+- Raspberry Pi (arm64) running Raspberry Pi OS 64-bit and [Docker Engine](https://docs.docker.com/engine/install/) (via the `docker-ce` package suite)
 
 Dockside requires a host with a minimum of 1GB memory.
 

--- a/docs/developing/building-image.md
+++ b/docs/developing/building-image.md
@@ -34,7 +34,7 @@ Here are the build options to `build/build.sh`:
 - `--help` - display all build options
 - `--builder <method>` - the choice of builder, 'buildkit', 'buildx' or 'depot' - the default is 'buildkit'
 - `--platform <platforms>` - a comma-separated list of platforms (architectures) to build for (subject to the choice of builder) -
-  for the 'depot' builder, the default is 'linux/amd64,linux/arm64,linux/arm/v7'; for the 'buildkit' and 'buildx' builders,
+  for the 'depot' builder, the default is 'linux/amd64,linux/arm64'; for the 'buildkit' and 'buildx' builders,
   the default is the native hardware platform.
 
 ## Examples

--- a/docs/developing/building-production-image.md
+++ b/docs/developing/building-production-image.md
@@ -11,7 +11,6 @@ We use [Depot](https://depot.dev/) to build multi-architecture images for Docksi
    ```sh
    ./build/build.sh --builder depot --tag test --platform linux/amd64
    ./build/build.sh --builder depot --tag test --platform linux/arm64
-   ./build/build.sh --builder depot --tag test --platform linux/arm/v7
    ```
    (These commands will each build an image called `newsnowlabs/dockside:test`)
 3. Build a multiplatform docker image for testing, pushing it to the image repository. (Please note, this commands executes quickly as it draws upon the cached image layers from the previous build steps.)

--- a/docs/extensions.md
+++ b/docs/extensions.md
@@ -6,5 +6,6 @@ A variety of extensions are available to facilitate advanced usage:
 - [Multi-architecture devtainers](extensions/multiarch.md) -- support for devtainers running non-amd64 processor architectures
 - [Alternative runtimes](extensions/runtimes.md) — Sysbox (Docker-in-Dockside), RunCVM (KVM VMs), and gVisor (sandboxed isolation)
 - [Integrated SSH server support](extensions/ssh.md) -- allows seamless SSH access to devtainers from the command line and accessing devtainers using VS Code
+- [SSH-only devtainers](extensions/ide.md) -- disable the IDE entirely, globally or per profile, to save RAM/CPU on constrained hosts
 - Firewall or redirect outgoing devtainer traffic using custom Docker networks.
 - Access Dockside devtainers via multiple domain names, when needed to stage or simulate multi-domain web applications

--- a/docs/extensions/ide.md
+++ b/docs/extensions/ide.md
@@ -1,0 +1,80 @@
+# SSH-only devtainers (no IDE)
+
+By default every devtainer runs a full browser IDE (Theia or OpenVSCode) alongside SSH access.
+On resource-constrained hosts — for example some Raspberry Pi boards — running the IDE is the
+single biggest RAM/CPU cost Dockside imposes. If you only need SSH access to a devtainer, you can
+disable the IDE entirely, globally or per profile, and let developers connect via
+[SSH](ssh.md) instead.
+
+## Disabling IDE globally
+
+Dockside enables the IDE by default for all new devcontainers. To disable it globally, set
+`"ide": { "default": false }` in `config.json`. To disable it in an individual profile, set
+`"ide": false` in the profile. Either way, a profile with the IDE switched off resolves its `IDEs`
+list to `["none"]` regardless of whatever real IDE patterns it configured, and no `ide` router is
+added — the devtainer never spends any resources launching an IDE.
+
+For maximum resource savings on a constrained host, combine this with SSH access — see
+[Integrated SSH server support](ssh.md).
+
+## Offering a choice between IDE and no IDE
+
+A profile can also offer developers a *choice*, rather than forcing IDE off for everyone. Add the
+literal string `"none"` to the profile's `IDEs` list alongside real IDE identifiers:
+
+```json
+"IDEs": ["theia/latest", "openvscode/latest", "none"]
+```
+
+`"none"` is never auto-discovered or implied by `["*"]` — a profile author must list it explicitly.
+It is never chosen as an implicit default either: `"none"` is always the last resort in a profile's
+resolved `IDEs` list, so a devtainer launched with no `--ide` specified always gets a real IDE if
+one is available, never `"none"`, by surprise.
+
+When a profile offers both `"none"` and a real IDE, the devtainer's `ide` router is still created
+even for a devtainer launched with `--ide none`. This is deliberate: Dockside cannot add a router to
+an existing devtainer's reservation after launch, so the route needs to already exist in case a
+developer picks a real IDE later. See "Enabling an IDE later" below.
+
+## Permission model
+
+`"none"` is treated exactly like any other IDE identifier for role/user permission purposes. If a
+role or user already has `resources.IDEs: ["*"]` (the default for new users), that grant already
+covers `"none"` the moment a profile offers it — no separate configuration is needed. To deny a
+specific role or user the ability to choose `"none"` while still allowing real IDEs, deny it
+explicitly:
+
+```json
+"resources": { "IDEs": { "*": 1, "none": 0 } }
+```
+
+"Explicit allow" for `"none"` is enforced at the profile level: an admin must deliberately add
+`"none"` to a profile's `IDEs` (or disable `ide` entirely) before any user can select it — it is
+never available "by accident."
+
+## Enabling an IDE later
+
+A devtainer launched with `--ide none` can get a real IDE later:
+
+```sh
+dockside edit my-devtainer --ide theia/latest
+```
+
+This updates the devtainer's stored IDE choice immediately, but — because there is no live
+in-place IDE switch — does not start the IDE in an already-running devtainer. Stop and start the
+devtainer for the change to take effect:
+
+```sh
+dockside stop my-devtainer
+dockside start my-devtainer
+```
+
+## Command-line usage
+
+```sh
+# Launch with no IDE (only valid if the profile, your user, and your role all permit it)
+dockside create --profile my-profile --ide none
+
+# Switch back to a real IDE later (see "Enabling an IDE later" above)
+dockside edit my-devtainer --ide openvscode/latest
+```

--- a/docs/extensions/ssh.md
+++ b/docs/extensions/ssh.md
@@ -15,6 +15,8 @@ Dockside's integrated SSH server support:
 
 Dockside enables SSH by default for all new devcontainers. To disable it globally, set `"ssh": { "default": false }` in `config.json`. To disable it in an individual profile, set `"ssh": false` in the profile.
 
+For maximum resource savings on constrained hosts, combine SSH-only access with disabling the IDE — see [SSH-only devtainers](ide.md).
+
 ### Configuring user public keys
 
 To control which developers can SSH into a devcontainer, add each developer's SSH public keys to their record in `users.json` under `ssh.publicKeys`, using a name of your choice for each key:

--- a/docs/setup.md
+++ b/docs/setup.md
@@ -65,7 +65,8 @@ The currently-supported root properties within a profile are:
 | unixusers | array of the unix user account for which to run the IDE | optional | `["dockside"]` | `["john","jim"]`
 | mounts | tmpfs, bind and/or volume mounts | optional | `{}` | `{ "tmpfs": [{ "dst": "/tmp","tmpfs-size": "1G"}], "volume": [{"src": "ssh-keys", "dst":"/home/mycompany/.ssh"}], "bind": [{"src": "/source/path", "dst": "/dest/path", "readonly": true}] }`
 | gitURLs | allowed git repository URLs that may be cloned on launch; use `["*"]` to allow any URL | optional | `[]` | `["https://github.com/myorg/*"]` or `["*"]`
-| IDEs | allowed IDE installations for the devtainer; use `["*"]` to allow all IDEs available in the Dockside image (under `/opt/dockside/ide/`) | optional | `["*"]` | `["theia/latest", "openvscode/latest"]`
+| IDEs | allowed IDE installations for the devtainer; use `["*"]` to allow all IDEs available in the Dockside image (under `/opt/dockside/ide/`); include the literal string `"none"` to also permit launching with no IDE at all (SSH-only) — see [SSH-only devtainers](extensions/ide.md) | optional | `["*"]` | `["theia/latest", "openvscode/latest", "none"]`
+| ide | whether the IDE subsystem is available at all for this profile; if `false`, `IDEs` resolves to `["none"]` regardless of any real IDE patterns configured — see [SSH-only devtainers](extensions/ide.md) | optional | as specified in `config.json` | `false` |
 | options | dynamic user-input fields displayed in the launch form; each entry has `name`, `label`, `type`, `default`, and `placeholder` sub-fields; values are injected into the container as `DOCKSIDE_OPTION_<NAME>` environment variables or via `entrypoint` or `command` placeholders of form `{option.<NAME>}` | optional | `[]` | `[{"name": "branch", "label": "Branch", "type": "text", "default": "", "placeholder": "e.g. main"}]`
 | runDockerInit | if true, run an init process inside the devtainer | optional | `true` | `true` |
 | dockerArgs | arguments to pass verbatim to docker | optional | `[]` | `["--memory", "2G", "--storage-opt", "size=1.2G","--pids-limit", "4000"]` |
@@ -85,6 +86,8 @@ Profiles using `["*"]` for `networks`, `runtimes`, or `IDEs` will present only t
 - **IDEs** are discovered by scanning the `/opt/dockside/ide/` directory for installed IDE versions (e.g. `theia/latest`, `openvscode/latest`).
 
 This means profiles using `["*"]` require no updates when new runtimes, networks, or IDEs become available (subject always to the resources the user is granted access to in `users.json` and `roles.json`).
+
+`"none"` (no IDE / SSH-only) is never auto-discovered or implied by `["*"]` — it is not a real installed IDE, so it must be listed explicitly in a profile's `IDEs`, or forced on for every devtainer via `ide: false` (per-profile) or `ide.default: false` (globally, in `config.json`). See [SSH-only devtainers](extensions/ide.md).
 
 #### Network name format
 
@@ -262,7 +265,7 @@ Available resource names are:
 - `profiles`: specify allowed profile filenames
 - `networks`: specify allowed Docker networks
 - `runtimes`: specify allowed Docker runtimes
-- `IDEs`: specify allowed IDE installations (e.g. `theia/latest`, `openvscode/latest`, or `openvscode/1.109.5`)
+- `IDEs`: specify allowed IDE installations (e.g. `theia/latest`, `openvscode/latest`, or `openvscode/1.109.5`), or the literal `"none"` to permit choosing no IDE (SSH-only) — treated exactly like any other IDE name, so an existing `["*"]` grant already covers `"none"` once a profile offers it; see [SSH-only devtainers](extensions/ide.md)
 - `images`: specify allowed Docker images
 - `auth`: specify allowed [auth/access levels](#router-auth%2Faccess-levels)
 
@@ -337,3 +340,5 @@ The `config.json` file contains global config for the Dockside instance. Not all
 - `docker.security`: the default `apparmor` and `seccomp` security profiles (may be overriden within Dockside profiles)
 - `ssh`:
     - `default`: a boolean indicating whether devtainers launched from profiles that do not contain an `ssh` property should have ssh access enabled (default true)
+- `ide`:
+    - `default`: a boolean indicating whether devtainers launched from profiles that do not contain an `ide` property should have the IDE subsystem enabled (default true); see [SSH-only devtainers](extensions/ide.md)

--- a/t/integration/tests/15_ide_none.py
+++ b/t/integration/tests/15_ide_none.py
@@ -1,0 +1,175 @@
+"""
+15_ide_none.py — the 'none' pseudo-IDE (SSH-only devtainers)
+
+Covers:
+  - A profile offering 'none' alongside a real IDE: creating with --ide none
+    succeeds, and the profile's 'ide' router still exists (so a real IDE can
+    be enabled later — routers can't be added post-launch).            [test_01]
+  - A profile with the IDE subsystem switched off ("ide": false): creating
+    with no --ide defaults to 'none', and no 'ide' router exists.       [test_02]
+  - Default IDE selection never silently picks 'none' when a real IDE is
+    also on offer.                                                      [test_03]
+  - Enabling an IDE later on a devtainer launched with 'none': edit updates
+    the stored choice immediately but does not live-switch a running
+    devtainer; a stop/start cycle then makes the IDE reachable.         [test_04]
+"""
+
+import json
+import os
+import sys
+import tempfile
+
+sys.path.insert(0, os.path.join(os.path.dirname(__file__), '..', 'lib'))
+
+from dockside_test import TestCase, APIError
+
+
+def _none_and_real_profile(name, image):
+    return {
+        'version': 2,
+        'name': name,
+        'active': True,
+        'routers': [
+            {
+                'name': 'www',
+                'prefixes': ['www'],
+                'domains': ['*'],
+                'https': {'protocol': 'http', 'port': 8080},
+                'auth': ['developer', 'owner', 'viewer', 'user', 'containerCookie', 'public'],
+            }
+        ],
+        'networks': ['*'],
+        'images': [image],
+        'unixusers': ['dockside'],
+        'IDEs': ['openvscode/latest', 'none'],
+        'mounts': {
+            'tmpfs': [{'dst': '/home/{ideUser}/.ssh', 'tmpfs-size': '1M'}],
+            'bind': [],
+            'volume': [],
+        },
+        'lxcfs': True,
+        'dockerArgs': ['--pids-limit=4000'],
+        'command': ['sleep', 'infinity'],
+    }
+
+
+def _ide_disabled_profile(name, image):
+    profile = _none_and_real_profile(name, image)
+    profile['ide'] = False
+    del profile['IDEs']  # let the global-off collapse override apply
+    return profile
+
+
+class IdeNoneTests(TestCase):
+    """The 'none' pseudo-IDE: router preservation, defaulting, permission model."""
+
+    @classmethod
+    def setUpClass(cls):
+        cls._profile_none_and_real = cls._sfx('inttest-ide-none-real')
+        cls._profile_ide_disabled = cls._sfx('inttest-ide-disabled')
+        cls._create_profile(
+            cls._profile_none_and_real,
+            _none_and_real_profile(cls._profile_none_and_real, cls.test_image_debian),
+        )
+        cls._create_profile(
+            cls._profile_ide_disabled,
+            _ide_disabled_profile(cls._profile_ide_disabled, cls.test_image_debian),
+        )
+
+    @classmethod
+    def _create_profile(cls, name, body):
+        with tempfile.NamedTemporaryFile('w', suffix='.json', delete=False) as fh:
+            json.dump(body, fh)
+            path = fh.name
+        try:
+            cls.admin._run('profile', 'create', name, '--from-json', path)
+        finally:
+            os.unlink(path)
+
+    @classmethod
+    def tearDownClass(cls):
+        for kind, name in (
+            ('profile', cls._profile_none_and_real),
+            ('profile', cls._profile_ide_disabled),
+        ):
+            try:
+                cls.admin._run(kind, 'remove', '--force', name)
+            except Exception:
+                pass
+
+    @staticmethod
+    def _has_ide_router(container_data):
+        routers = ((container_data.get('profileObject') or {}).get('routers')) or []
+        return any(r.get('type') == 'ide' for r in routers)
+
+    def test_01_none_chosen_router_still_present(self):
+        """Profile offers 'none' + a real IDE; picking 'none' still gets the ide router."""
+        name = self._sfx('inttest-ide-none-01')
+        self.register_cleanup(name)
+        self.create_and_wait(
+            self.admin, self._profile_none_and_real, name, timeout=180, ide='none'
+        )
+        data = self.admin.get_container(name)
+        self.assert_equal(data.get('meta', {}).get('IDE'), 'none',
+                          f'expected meta.IDE == none, got {data.get("meta")!r}')
+        self.assert_true(
+            self._has_ide_router(data),
+            "profile offering 'none' + a real IDE should still get an 'ide' router"
+        )
+
+    def test_02_ide_disabled_profile_defaults_to_none_no_router(self):
+        """Profile has the IDE subsystem off; default launch resolves to 'none', no router."""
+        name = self._sfx('inttest-ide-none-02')
+        self.register_cleanup(name)
+        self.create_and_wait(self.admin, self._profile_ide_disabled, name, timeout=180)
+        data = self.admin.get_container(name)
+        self.assert_equal(data.get('meta', {}).get('IDE'), 'none',
+                          f'expected default meta.IDE == none, got {data.get("meta")!r}')
+        self.assert_true(
+            not self._has_ide_router(data),
+            "profile with the IDE subsystem off should have no 'ide' router"
+        )
+
+    def test_03_default_never_picks_none(self):
+        """On a profile offering both, launching with no --ide never resolves to 'none'."""
+        name = self._sfx('inttest-ide-none-03')
+        self.register_cleanup(name)
+        self.create_and_wait(self.admin, self._profile_none_and_real, name, timeout=180)
+        data = self.admin.get_container(name)
+        self.assert_equal(data.get('meta', {}).get('IDE'), 'openvscode/latest',
+                          f'default IDE should be the real IDE, not none: {data.get("meta")!r}')
+
+    def test_04_enable_ide_later_via_stop_start(self):
+        """edit updates the stored IDE immediately but does not live-switch a running
+        devtainer; a stop/start cycle then makes the newly-chosen IDE reachable."""
+        name = self._sfx('inttest-ide-none-04')
+        self.register_cleanup(name)
+        self.create_and_wait(
+            self.admin, self._profile_none_and_real, name, timeout=180, ide='none'
+        )
+
+        self.admin.update(name, ide='openvscode/latest')
+        data = self.admin.get_container(name)
+        self.assert_equal(data.get('meta', {}).get('IDE'), 'openvscode/latest',
+                          f'edit should update the stored IDE immediately: {data.get("meta")!r}')
+
+        self.admin.stop(name, wait=True, timeout=60)
+        self.admin.start(name, wait=True, timeout=180)
+
+        try:
+            def _ide_ready():
+                try:
+                    code, _ = self.admin.check_service(name, router_prefix='ide')
+                    return code if code != 502 else None
+                except APIError:
+                    return None
+            code = self.wait_until(
+                _ide_ready, timeout=120, interval=3,
+                timeout_msg='IDE backend did not become ready after enabling it and restarting',
+            )
+            self.assert_true(
+                code in (200, 302, 301, 303),
+                f'IDE URL returned unexpected status {code}'
+            )
+        except APIError as e:
+            self.skip(f'Could not reach IDE URL: {e}')


### PR DESCRIPTION
## Summary
- Lets a devtainer run with no IDE at all (SSH-only), gated by a new `config.json` `ide.default` / per-profile `ide` boolean (mirrors `ssh`/`ssh.default`) and a `"none"` pseudo-IDE a profile can list in `IDEs` alongside real IDEs.
- `"none"` is validated and permission-gated through the exact same profile/role/user machinery as any real IDE identifier, is never picked as an implicit default, and still gets the profile's `ide` router provisioned at reservation-creation time when offered alongside a real IDE — since routers can't be added to a reservation post-launch, the route must already exist for a devtainer launched with `none` to be switched to a real IDE later.
- `launch.sh`'s `restart_ide()` gets a real no-op arm for `IDE=none`.
- CLI/UI: `--ide` help text, a friendly "No IDE (SSH only)" label/suggestion, and a clearer permission-denial message listing the caller's actually-permitted IDE choices.
- New `docs/extensions/ide.md`, plus `setup.md`/`ssh.md` updates.

## Depends on
This branch's `ide:false` / none-only-profile *default* path (no explicit `--ide none`) needs the fix on [`devel-20260801-fix-ide-default-resolution`](https://github.com/newsnowlabs/dockside/tree/devel-20260801-fix-ide-default-resolution) to actually resolve to `none` — that branch fixes a separate, pre-existing bug (unrelated to this feature in principle) where `dockside create` with no `--ide` flag never persisted a resolved default IDE at all. Marking this **draft** until that fix lands; without it, an explicit `--ide none` still works correctly.

## Test plan
- [x] `./test.sh` (Perl compile, Vue build, ESLint, StyleLint, ShellCheck, JSON/YAML) — all pass
- [x] Vue bundle rebuilt; server Perl + `launch.sh` deployed to this host's own `mountIDE:false` instance and services restarted
- [x] New `t/integration/tests/15_ide_none.py` (4 scenarios: router preserved when `none` + real IDE offered, `ide:false` profile defaults to `none` with no router, default never picks `none` when a real IDE is available, enabling an IDE later via `edit` + stop/start) — all pass (requires the dependency fix above)
- [x] Full integration suite regression run — 111 passed, 0 failed, 3 pre-existing skips

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01UgNGsJacEVaaZz2usNPQWn