### PR TITLE
Fix five recurring Perl 'uninitialized value' warnings

### DIFF
--- a/app/server/lib/App.pm
+++ b/app/server/lib/App.pm
@@ -85,6 +85,10 @@ sub log_status ($sub, $json) {
 #
 
 sub split_args ($queryString) {
+   # $queryString is undef whenever the request URL has no query string at all
+   # (e.g. $r->args on a plain GET); treat that the same as an empty string.
+   $queryString //= '';
+
    # Split querystring-style arguments, and unescape them
    my %hash = map { uri_unescape($_) } split( /[=&]/, $queryString );
 

--- a/app/server/lib/Reservation.pm
+++ b/app/server/lib/Reservation.pm
@@ -1128,7 +1128,10 @@ sub exec ($reservation, $command = undef) {
 
    my @envGit;
    if( $reservation->gitURL() ) {
-      my ($git_domain) = $reservation->gitURL() =~ m!^(?:https://|git@)([^:/]+)!;
+      # SCP-style URLs may use any username (see the gitURL validation regex
+      # above), not just literally 'git@' - match that here too, else
+      # $git_domain is left undef for e.g. 'deploy@host:path'.
+      my ($git_domain) = $reservation->gitURL() =~ m!^(?:https://|[a-zA-Z][\w-]*@)([^:/]+)!;
       @envGit = (
          "--env=GIT_URL=" . $reservation->gitURL(),
          "--env=SSH_KNOWN_HOSTS_DOMAINS=$git_domain"

--- a/app/server/lib/Reservation.pm
+++ b/app/server/lib/Reservation.pm
@@ -324,8 +324,9 @@ sub new ($class, $data, $validated = 0) {
    bless $self, ( ref($class) || $class );
 
    # If a dummy Reservation object has been requested for sending to the client,
-   # return what we have now.
-   if( $data->{'id'} eq 'new' ) {
+   # return what we have now. $data->{'id'} is absent (undef) for a genuinely
+   # new reservation being created, not just for the 'new' dummy-object request.
+   if( ($data->{'id'} // '') eq 'new' ) {
       return $self;
    }
 

--- a/app/server/lib/Reservation/Mutate.pm
+++ b/app/server/lib/Reservation/Mutate.pm
@@ -78,7 +78,8 @@ sub update ($self, $e) {
          $by_id->{$id} //= {};
 
          # Remove BY_HOST index entry for old 'name' key on this id, in case 'name' key value has changed.
-         delete $by_name->{ $by_id->{$id}{'name'} };
+         # (A brand-new id has no prior 'name' yet - nothing to remove.)
+         delete $by_name->{ $by_id->{$id}{'name'} } if defined $by_id->{$id}{'name'};
 
          # Copy across all values that are different.
          cloneHash($e, $by_id->{$id});

--- a/app/server/lib/User.pm
+++ b/app/server/lib/User.pm
@@ -775,6 +775,14 @@ sub set ($self, $reservation, $property, $value = '') {
          };
       }
 
+      # $value ne '' above leaves $value as '' (not decoded) whenever no access was
+      # requested - previously that meant $value stayed undef, and Perl reads undef->{$name}
+      # below as an empty map without complaint; now that the top-of-sub $value //= '' means
+      # a real, defined '' reaches here instead, the same read would die ("Can't use string
+      # as a HASH ref") under strict refs. Normalise explicitly rather than depending on
+      # that undef-specific leniency.
+      $value = {} unless ref($value) eq 'HASH';
+
       my $oldAccess = $reservation->meta('access');
       my $newAccess = {};
 

--- a/app/server/lib/User.pm
+++ b/app/server/lib/User.pm
@@ -581,6 +581,12 @@ sub reservation ($self, $arg = undef) {
 # Returns truthy if user is authorised to set $property to $value
 # Returns falsey if not.
 sub set ($self, $reservation, $property, $value = '') {
+   # Signature defaults fire based on arg count, not definedness - createContainerReservation/
+   # updateContainerReservation always pass 4 args, even when the caller's $args->{$m} is
+   # absent, so the '' default above never fires here. Normalise undef to '' explicitly so
+   # every eq/ne branch below sees '' for "no value supplied".
+   $value //= '';
+
    if( $property eq 'profile') {
 
       # Not permitted
@@ -695,10 +701,6 @@ sub set ($self, $reservation, $property, $value = '') {
 
    elsif( $property eq 'IDE') {
 
-      # A create() request that omits --ide entirely reaches here with $value
-      # undef (the field is absent from the request, not merely blank) - treat
-      # that the same as ''  (no explicit choice).
-      $value //= '';
       my $current = $reservation->meta('IDE') // '';
 
       # Permitted, if no change in value is requested, or empty value requested


### PR DESCRIPTION
## Summary

Five independent fixes for "Use of uninitialized value" warnings seen in production logs, each traced to a distinct root cause:

- **`split_args` (App.pm)**: `$r->args` is `undef` for any request URL with no query string (the common case for plain GETs/POSTs), so `split_args()` was regularly called with `undef`.
- **`Reservation->new` (Reservation.pm)**: `createContainerReservation` builds a brand-new `Reservation->new({...})` with no `'id'` key at all, so the `'id' eq 'new'` dummy-object check ran against `undef` on every real container launch.
- **`User::set` (User.pm)**: `createContainerReservation`/`updateContainerReservation` always call `set($reservation, $m, $args->{$m})` with 4 positional args, even when `$args->{$m}` is absent. Perl signature defaults key on arg count, not definedness, so `$value = ''` in the signature never fires here. Normalised `$value` once at the top of the sub instead of only in the `IDE` branch (which had already worked around this locally).
- **`Reservation::Mutate::update` (Reservation/Mutate.pm)**: on first store of a brand-new reservation, `$by_id->{$id}{'name'}` doesn't exist yet, so the cleanup `delete` targeted an undef key.
- **`gitURL` → `SSH_KNOWN_HOSTS_DOMAINS` (Reservation.pm)**: this one is an actual functional bug, not just cosmetic — the domain-extraction regex only matched a literal `git@` prefix, but the gitURL validator accepts any SCP-style username (e.g. `deploy@host:path`). For any non-`git` username, `$git_domain` stayed undef and `SSH_KNOWN_HOSTS_DOMAINS` silently ended up empty.

Five separate commits, one per fix, for easy review/bisection.

## Test plan

- [x] `./test.sh --only perl` passes
- [ ] Restart `nginx`/`docker-event-daemon` services and exercise container launch/update flows to confirm the warnings no longer appear in logs

Co-Authored-By: Claude Sonnet 5 <noreply@anthropic.com>

https://claude.ai/code/session_01L3hxVJRp5aV8t9kiS9yD71