### PR TITLE
Fix git repo checkout being broken/stale on every restart

### DIFF
--- a/app/scripts/container/launch.sh
+++ b/app/scripts/container/launch.sh
@@ -269,7 +269,15 @@ checkout_git_branch_or_pr() {
    if (
       cd "$REPO" &&
       git fetch origin "refs/heads/$BRANCH:refs/remotes/origin/$BRANCH" &&
-      { git switch "$BRANCH" 2>/dev/null || git switch --track -c "$BRANCH" "origin/$BRANCH"; }
+      { git switch "$BRANCH" 2>/dev/null || git switch --track -c "$BRANCH" "origin/$BRANCH"; } &&
+      # A pre-existing local branch of this name (e.g. baked into the image, or left
+      # over from an earlier launch) is not touched by 'switch' above - only the
+      # just-fetched origin/$BRANCH ref advances. Fast-forward explicitly so a
+      # repeat launch/restart actually converges on the latest commit instead of
+      # silently staying on a stale one; --ff-only fails loudly rather than
+      # discarding local commits if history has diverged (a freshly-tracked branch
+      # is already at this commit, so this is a no-op there).
+      git merge --ff-only "origin/$BRANCH"
    ); then
       log "Checked out branch $BRANCH in $REPO"
       return 0

--- a/app/scripts/container/launch.sh
+++ b/app/scripts/container/launch.sh
@@ -179,6 +179,14 @@ launch_sshd() {
    fi
 }
 
+# Returns 0 if a fresh clone just succeeded, 1 if the clone failed, 2 if the repo
+# already existed (a restart) and the clone was skipped. The caller uses this to
+# decide whether to run checkout_git_branch_or_pr at all: DOCKSIDE_OPTION_BRANCH/PR
+# are fixed at reservation-creation time and can never change, so that checkout
+# should only ever run once, right after a genuine fresh clone - re-running it on
+# every restart has nothing new to do, and would fail loudly (by design, to protect
+# local work) on every single restart from then on if local history has since
+# diverged from origin, not just once.
 create_git_repo() {
    [ -n "$GIT_URL" ] || return 0
 
@@ -186,7 +194,7 @@ create_git_repo() {
    CLONE_DIR=$(basename "${GIT_URL%.git}")
    if [ -d "$HOME/$CLONE_DIR/.git" ]; then
       log "Repo '$HOME/$CLONE_DIR' already exists; skipping clone (already set up by an earlier launch)"
-      return 0
+      return 2
    fi
 
    log "- Running: git clone $GIT_URL"
@@ -714,32 +722,50 @@ run_nonroot() {
    populate_known_hosts
    (
       log "Repo setup subproc started ..."
-      # A failed clone is a hard error: there is no repository to set up, so abort
-      # before any sentinel is written (checkout_git_branch_or_pr would otherwise
-      # return 0 on the absent repo and let .git-repo-ready be touched anyway).
-      if ! create_git_repo; then
-         dockside_user_warning "Git clone of '$GIT_URL' failed; the repository was not set up (see $LOG)."
-         touch "$LOG_PATH/.git-repo-failed"
-         exit 1
-      fi
-      gh_authenticate
-      # A requested branch/PR checkout failure is a hard error: abort the rest of repo
-      # setup, log it, and write .git-repo-failed instead of the success sentinel so a
-      # consumer can detect it immediately rather than waiting for a timeout.
-      #
-      # On success (or when no branch/PR was requested), write .git-repo-ready. With a
-      # hard clone failure now handled above, this signals that a GIT_URL clone
-      # succeeded and any requested branch/PR was checked out; it does NOT wait for the
-      # later VS Code population, and Dockside does not guarantee an otherwise error-free
-      # working tree, so .git-repo-ready is gated on a non-empty GIT_URL and its sole
-      # consumer (t/integration/tests/06_git_profile.py) still verifies the repo state.
-      if checkout_git_branch_or_pr; then
-         [ -n "$GIT_URL" ] && touch "$LOG_PATH/.git-repo-ready"
-      else
-         dockside_user_warning "Checkout of the requested branch/PR failed; the repository may be on the wrong ref (see $LOG)."
-         touch "$LOG_PATH/.git-repo-failed"
-         exit 1
-      fi
+      create_git_repo
+      case $? in
+         0)
+            # A fresh clone just succeeded: this is the one invocation where
+            # checkout_git_branch_or_pr is meant to run (see its own return-code
+            # comment on create_git_repo above).
+            gh_authenticate
+            # A requested branch/PR checkout failure is a hard error: abort the rest of repo
+            # setup, log it, and write .git-repo-failed instead of the success sentinel so a
+            # consumer can detect it immediately rather than waiting for a timeout.
+            #
+            # On success (or when no branch/PR was requested), write .git-repo-ready. With a
+            # hard clone failure now handled above, this signals that a GIT_URL clone
+            # succeeded and any requested branch/PR was checked out; it does NOT wait for the
+            # later VS Code population, and Dockside does not guarantee an otherwise error-free
+            # working tree, so .git-repo-ready is gated on a non-empty GIT_URL and its sole
+            # consumer (t/integration/tests/06_git_profile.py) still verifies the repo state.
+            if checkout_git_branch_or_pr; then
+               [ -n "$GIT_URL" ] && touch "$LOG_PATH/.git-repo-ready"
+            else
+               dockside_user_warning "Checkout of the requested branch/PR failed; the repository may be on the wrong ref (see $LOG)."
+               touch "$LOG_PATH/.git-repo-failed"
+               exit 1
+            fi
+            ;;
+         2)
+            # Repo already existed from an earlier launch (a restart): the clone was
+            # skipped, so deliberately do NOT run checkout_git_branch_or_pr again -
+            # see the comment on create_git_repo for why. gh_authenticate still runs
+            # unconditionally here, same as on a fresh clone, since it's general
+            # auth setup unrelated to branch/PR checkout specifically.
+            gh_authenticate
+            [ -n "$GIT_URL" ] && touch "$LOG_PATH/.git-repo-ready"
+            ;;
+         *)
+            # A failed clone is a hard error: there is no repository to set up, so
+            # abort before any sentinel is written (checkout_git_branch_or_pr would
+            # otherwise return 0 on the absent repo and let .git-repo-ready be
+            # touched anyway).
+            dockside_user_warning "Git clone of '$GIT_URL' failed; the repository was not set up (see $LOG)."
+            touch "$LOG_PATH/.git-repo-failed"
+            exit 1
+            ;;
+      esac
       populate_vscode_extensions;
       populate_vscode_settings
       log "Repo setup subproc finished";

--- a/app/scripts/container/launch.sh
+++ b/app/scripts/container/launch.sh
@@ -711,7 +711,14 @@ run_nonroot() {
    log "User account launch started ..."
    # Surface launch-time warnings to the user's interactive shells: clear any stale
    # warnings from a previous launch, then ensure the rc snippet is installed.
-   rm -f "$LOG_PATH/launch-status.txt" 2>/dev/null
+   # Also clear .git-repo-ready/.git-repo-failed from a previous launch here, for
+   # the same reason: /tmp survives a stop/start, so a stale .git-repo-ready sitting
+   # here from a prior successful launch would otherwise still read as "ready" the
+   # instant this launch starts - before create_git_repo/checkout_git_branch_or_pr
+   # have run again this time - masking a genuine failure on this restart (verified:
+   # a stale .git-repo-ready and a freshly-written .git-repo-failed can coexist,
+   # each with its own launch's timestamp, until this clear removes the former).
+   rm -f "$LOG_PATH/launch-status.txt" "$LOG_PATH/.git-repo-ready" "$LOG_PATH/.git-repo-failed" 2>/dev/null
    install_launch_status_notice
    spawn_ssh_agent
    # A failed key load is non-fatal (the IDE still launches), but no longer silent:

--- a/app/scripts/container/launch.sh
+++ b/app/scripts/container/launch.sh
@@ -182,6 +182,13 @@ launch_sshd() {
 create_git_repo() {
    [ -n "$GIT_URL" ] || return 0
 
+   local CLONE_DIR
+   CLONE_DIR=$(basename "${GIT_URL%.git}")
+   if [ -d "$HOME/$CLONE_DIR/.git" ]; then
+      log "Repo '$HOME/$CLONE_DIR' already exists; skipping clone (already set up by an earlier launch)"
+      return 0
+   fi
+
    log "- Running: git clone $GIT_URL"
    # Detect clone failure explicitly: without this the function returned the
    # status of the trailing gitconfig block, so a failed clone went unnoticed and

--- a/t/integration/tests/06_git_profile.py
+++ b/t/integration/tests/06_git_profile.py
@@ -8,12 +8,16 @@ Coverage:
   - launch writes the owner's git name/email into ~/.gitconfig
   - launch clones the requested repo into the unix user's home directory
   - explicit branch / PR launch options affect the resulting checkout state
+  - a stop/start restart neither spuriously fails repo setup nor disturbs an
+    already-checked-out branch (create_git_repo/checkout_git_branch_or_pr's
+    restart handling)
 """
 
 import sys
 import os
 import json
 import subprocess
+import time
 sys.path.insert(0, os.path.join(os.path.dirname(__file__), '..', 'lib'))
 
 from dockside_test import TestCase, APIError, CapabilityUnavailable
@@ -38,12 +42,20 @@ class GitProfileTests(TestCase):
         '[ -x "$git_bin" ] || git_bin=git; '
         'printf "git_ready=%s\\n" "$(test -f /tmp/dockside/.git-repo-ready && echo 1 || echo 0)"; '
         'printf "git_failed=%s\\n" "$(test -f /tmp/dockside/.git-repo-failed && echo 1 || echo 0)"; '
+        # mtime (epoch seconds) of .git-repo-ready, not just its presence - it is
+        # never cleared before a launch re-touches it, so a stale ready sentinel
+        # from a PREVIOUS launch can still read as "ready" the instant a restart's
+        # container starts, before this launch's own repo setup has run at all.
+        # Comparing this against a wall-clock time recorded just before the
+        # restart is what proves the file was genuinely rewritten this time.
+        'printf "git_ready_mtime=%s\\n" "$(stat -c %Y /tmp/dockside/.git-repo-ready 2>/dev/null || true)"; '
         'printf "gitconfig_name=%s\\n" "$("$git_bin" config -f "$home/.gitconfig" --get user.name 2>/dev/null || true)"; '
         'printf "gitconfig_email=%s\\n" "$("$git_bin" config -f "$home/.gitconfig" --get user.email 2>/dev/null || true)"; '
         'printf "repo_exists=%s\\n" "$(test -d "$repo/.git" && echo 1 || echo 0)"; '
         'printf "origin_url=%s\\n" "$("$git_bin" -C "$repo" remote get-url origin 2>/dev/null || true)"; '
         'printf "branch=%s\\n" "$("$git_bin" -C "$repo" rev-parse --abbrev-ref HEAD 2>/dev/null || true)"; '
-        'printf "head_ref=%s\\n" "$(cat "$repo/.git/HEAD" 2>/dev/null || true)"'
+        'printf "head_ref=%s\\n" "$(cat "$repo/.git/HEAD" 2>/dev/null || true)"; '
+        'printf "head_sha=%s\\n" "$("$git_bin" -C "$repo" rev-parse HEAD 2>/dev/null || true)"'
     )
 
     def _debug(self, msg):
@@ -278,3 +290,73 @@ class GitProfileTests(TestCase):
             image=self.test_image_ubuntu,
         )
         self.assert_true(result is not None)
+
+    def test_06_restart_preserves_git_state(self):
+        """A stop/start restart must neither spuriously fail repo setup nor
+        disturb an already-checked-out branch.
+
+        Guards against the create_git_repo/checkout_git_branch_or_pr restart bug:
+        create_git_repo previously had no idempotency check, so it unconditionally
+        re-ran `git clone` on every restart - which fails outright into the
+        already-populated directory - spuriously reporting .git-repo-failed and
+        skipping branch checkout on every restart after the first, forever.
+
+        checkout_git_branch_or_pr must also not simply be re-run on restart, not
+        just have its clone-failure fixed: DOCKSIDE_OPTION_BRANCH/PR are fixed at
+        reservation-creation time and can never change, so re-running it on
+        restart has nothing new to do - and would fail loudly (by design, to
+        protect any local work made since) if history has since diverged. head_sha
+        being unchanged below is what confirms it was skipped rather than merely
+        re-running as a no-op.
+        """
+        name = self._sfx('inttest-git-restart')
+        self._create_git_container(
+            name,
+            options=json.dumps({'branch': EXPLICIT_BRANCH}),
+        )
+        before = self._wait_git_state(
+            name,
+            lambda s: s.get('git_ready') == '1' and s.get('branch') == EXPLICIT_BRANCH,
+            f'branch {EXPLICIT_BRANCH!r} checkout did not complete before restart',
+            timeout=60,
+        )
+        head_sha_before = before.get('head_sha')
+        self.assert_true(bool(head_sha_before), 'no HEAD commit recorded before restart')
+
+        # .git-repo-ready is never cleared before a launch re-touches it (/tmp
+        # survives a stop/start), so it can still read as "ready" the instant this
+        # restart's container starts, well before this launch's own repo setup has
+        # run at all - a naive "does it exist" check would pass on that stale
+        # leftover without ever observing whether THIS restart actually succeeded.
+        # Recording a timestamp now and requiring git_ready_mtime to be newer than
+        # it is what makes the wait below observe this restart specifically.
+        restart_time = time.time()
+        self.dev1.stop(name, wait=True, timeout=60)
+        self.dev1.start(name, wait=True, timeout=120)
+
+        # _wait_git_state's own predicate already raises immediately if
+        # .git-repo-failed appears during this poll (see its definition above) -
+        # the core regression this test guards against. The assertions below are
+        # a belt-and-braces check against the state it actually returns.
+        after = self._wait_git_state(
+            name,
+            lambda s: (s.get('git_ready') == '1'
+                       and float(s.get('git_ready_mtime') or 0) > restart_time),
+            'repo setup did not report a freshly-touched .git-repo-ready after '
+            'restart (a stale one left over from before the restart does not count)',
+            timeout=60,
+        )
+        self.assert_equal(
+            after.get('git_failed'), '0',
+            'restart spuriously reported .git-repo-failed',
+        )
+        self.assert_equal(after.get('repo_exists'), '1')
+        self.assert_equal(
+            after.get('branch'), EXPLICIT_BRANCH,
+            'branch checkout was disturbed by the restart',
+        )
+        self.assert_equal(
+            after.get('head_sha'), head_sha_before,
+            'HEAD commit moved across a restart - checkout_git_branch_or_pr ran '
+            'again when it should have been skipped',
+        )


### PR DESCRIPTION
## Summary

Two independent, pre-existing bugs in `checkout_git_branch_or_pr()`'s support machinery
(`app/scripts/container/launch.sh`), found while investigating an unrelated in-progress
feature branch but fully independent of it — confirmed present, unchanged, on `main`.

- `create_git_repo()` has no idempotency check, so it unconditionally re-runs `git clone` on
  every container restart, which fails outright into the already-populated directory. The
  caller treats that as a hard error: it warns the user their clone failed, writes
  `.git-repo-failed`, and aborts before ever reaching branch/PR checkout — even though nothing
  is actually wrong.
- `git switch "$BRANCH"` only moves HEAD to wherever a pre-existing local branch already
  points — it does not fast-forward from the just-fetched `origin/$BRANCH`. So a branch checked
  out on one launch never actually advances on a later restart, even though the fetch itself
  succeeds every time.

Together these mean: today, restarting a `GIT_URL`-based devtainer spuriously reports a git
clone failure and leaves the branch checkout silently stale forever, on every restart after
the first.

A third, related bug surfaced while testing the fast-forward fix: `DOCKSIDE_OPTION_BRANCH`/`PR`
are fixed at reservation-creation time and can never change, so there's no legitimate reason to
re-run branch/PR checkout on a restart at all — and doing so is actively harmful. If a developer
has made any local commit since first launch (completely normal usage) while origin has also
moved on, the fast-forward correctly refuses to discard it, but without gating, that refusal
would fire on *every* restart from then on, permanently surfacing a "Checkout... failed" warning
even though nothing is wrong.

A fourth, related bug surfaced while adding the integration test for all of the above:
`.git-repo-ready` is never cleared before a launch re-touches it, so a stale one left over from
the first launch reads as "ready" the instant a restart's container starts — masking the very
regressions this PR fixes from an external observer (including, initially, this PR's own new
test — see below).

## Fixes (one commit each)

1. Skip the clone in `create_git_repo()` when the repo already exists.
2. Add `git merge --ff-only "origin/$BRANCH"` after `switch` succeeds — a no-op on a freshly
   tracked branch, a correct fast-forward on a stale pre-existing one, and a loud failure
   (rather than silent discard) if local history has genuinely diverged, e.g. unpushed commits
   made inside the devtainer.
3. Give `create_git_repo()` a third, distinct return code (`2`, alongside `run_hook()`'s existing
   convention of using non-0/1 codes for a distinct outcome) for "already existed, clone
   skipped", and have the caller skip `checkout_git_branch_or_pr()` entirely on that path —
   rather than only skipping its fast-forward — going straight to `.git-repo-ready`. A fresh
   clone still runs the checkout exactly as before, where the fast-forward is always a no-op
   anyway (already at the just-fetched tip).
4. Clear `.git-repo-ready`/`.git-repo-failed` at the start of `run_nonroot`, alongside the
   existing `launch-status.txt` clear — the same class of staleness bug as the
   `.hook-ready`/`.credentials-ready` sentinels elsewhere in this file.
5. Add an integration test (`06_git_profile.py`) exercising a real stop/start restart, verified
   in both directions against a live Dockside instance (fails clearly against the pre-fix code,
   passes against the fix).

## Test plan

- [x] `./test.sh --only shellcheck` and `--only python` pass
- [x] Verified against live scratch git repos by sourcing the actual patched functions
      (including the real `run_nonroot` dispatch logic, not just the two functions in
      isolation):
  - Fresh clone + first checkout succeeds, lands on the expected commit
  - Simulated restart: `create_git_repo` now returns `2` instead of failing with exit 128, and
    `checkout_git_branch_or_pr` is correctly skipped rather than re-run
  - Simulated restart with a clean upstream advance (commits 1+2's test, prior to commit 3):
    local branch fast-forwards to the new commit
  - Simulated restart with an unpushed local commit *and* origin having advanced: exits cleanly
    with `.git-repo-ready` touched and no warning; the local commit is left completely
    untouched — where it would previously (with only commits 1+2) have failed loudly on that
    restart, and every restart thereafter
- [x] Verified end-to-end against a real, live Dockside instance (not just scratch repos):
      deployed each version of `launch.sh` to `/opt/dockside/bin/launch.sh`, restarted
      `nginx`/`docker-event-daemon`, and launched/stopped/started real devtainers via the CLI:
  - Reproduced the `.git-repo-ready`/`.git-repo-failed` staleness bug directly: both sentinels
    coexisted on disk after a restart against the pre-fix code, each with its own launch's
    timestamp (`.git-repo-ready` from the first launch, `.git-repo-failed` ~57s later from the
    restart)
  - The new integration test (`06_git_profile.py::test_06_restart_preserves_git_state`) fails
    with a clear `.git-repo-failed` message when run against `launch.sh` before these fixes,
    and passes against the fully fixed version — confirmed in both directions, not just that
    it's green
  - All existing `06_git_profile.py` tests (1–5) continue to pass unaffected

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01KM83vcL7iCBGCDNnJfoYes
