### PR TITLE
Fix two preexisting bugs: Profile.pm default_gitURL, launch.sh DEBUG dump

### DIFF
--- a/app/scripts/container/launch.sh
+++ b/app/scripts/container/launch.sh
@@ -853,7 +853,7 @@ init() {
    log "- IDE_PATH=$IDE_PATH"
    if [ -n "$DEBUG" ]; then
       log "- Environment:"
-      busybox env | busybox sed 's/^/=> /'}
+      busybox env | busybox sed 's/^/=> /'
    fi
 }
 

--- a/app/server/lib/Profile.pm
+++ b/app/server/lib/Profile.pm
@@ -657,7 +657,7 @@ sub default_image ($self) {
 }
 
 sub default_gitURL ($self) {
-   my @nonWildcardGitURLs = grep { !/\*/ } @{$self->{'GitURLs'}};
+   my @nonWildcardGitURLs = grep { !/\*/ } @{$self->{'gitURLs'}};
    return $nonWildcardGitURLs[0] if @nonWildcardGitURLs;
 
    # Default gitURL is '' if none is specified


### PR DESCRIPTION
Two small, unrelated correctness fixes found while auditing `claude/ded-async-rewrite` (see `docs/plans/ded-async-rewrite-quality-audit.md`, findings appendix) — both predate that branch, so landing them on `main` first.

1. `Profile.pm`'s `default_gitURL()` read `$self->{'GitURLs'}` (capital G) instead of `gitURLs` — always returned `''` silently, for every profile.
2. `launch.sh`'s `DEBUG=1` environment dump had a stray trailing `}` breaking the sed script.

🤖 Generated with [Claude Code](https://claude.com/claude-code)